### PR TITLE
Member Entity 생성, 이메일 중복 체크API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/src/main/resources/*.yml
-**/src/main/resources/*.properties
 **/src/test/resources/*.yml
-**/src/test/resources/*.properties
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
  */
 buildscript {
 	ext {
-		springBootVersion = '2.6.4'
+		springBootVersion = '2.5.4'
 	}
 	repositories {
 		mavenCentral()
@@ -43,7 +43,6 @@ subprojects {
 	dependencies {
 		annotationProcessor 'org.projectlombok:lombok'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
-		testImplementation 'com.h2database:h2'
 	}
 
 	tasks.named('test') {
@@ -58,5 +57,11 @@ project(':module-api') {
 	dependencies {
 		implementation project(':module-common')
 		implementation project(':module-domain')
+	}
+}
+
+project(':module-domain') {
+	dependencies {
+		implementation project(':module-common')
 	}
 }

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -1,11 +1,3 @@
-bootJar {
-    enabled = false
-}
-
-jar {
-    enabled = true
-}
-
 dependencies {
     api group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
     api group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'

--- a/module-api/src/main/java/com/zoopi/ZoopiApplication.java
+++ b/module-api/src/main/java/com/zoopi/ZoopiApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ZoopiApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(ZoopiApplication.class);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ZoopiApplication.class, args);
+	}
 }

--- a/module-api/src/main/java/com/zoopi/controller/ResultCode.java
+++ b/module-api/src/main/java/com/zoopi/controller/ResultCode.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResultCode {
 
+	// Member
+	EMAIL_AVAILABLE(200, "R-M001", "사용 가능한 이메일입니다."),
+	EMAIL_DUPLICATE(200, "R-M002", "이미 사용 중인 이메일입니다."),
 	;
 
 	private final int status;

--- a/module-api/src/main/java/com/zoopi/controller/member/MemberController.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/MemberController.java
@@ -1,0 +1,50 @@
+package com.zoopi.controller.member;
+
+import static com.zoopi.controller.ResultCode.*;
+
+import javax.validation.constraints.Email;
+
+import org.hibernate.validator.constraints.Length;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zoopi.controller.ResultCode;
+import com.zoopi.controller.ResultResponse;
+import com.zoopi.controller.member.response.EmailValidationResponse;
+import com.zoopi.domain.member.service.MemberService;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+
+@Api(tags = "회원 인증 API")
+@Validated
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@ApiOperation(value = "이메일 중복 체크")
+	@PostMapping("/email/validate")
+	public ResponseEntity<ResultResponse> validateEmail(@RequestParam @Length(max = 30) @Email String email) {
+		final boolean isValidated = memberService.validateEmail(email);
+		final ResultCode resultCode;
+		if (isValidated) {
+			resultCode = EMAIL_AVAILABLE;
+		} else {
+			resultCode = EMAIL_DUPLICATE;
+		}
+
+		final EmailValidationResponse response = EmailValidationResponse.builder()
+			.email(email)
+			.isValidated(isValidated)
+			.build();
+		return ResponseEntity.ok(ResultResponse.of(resultCode, response));
+	}
+}

--- a/module-api/src/main/java/com/zoopi/controller/member/response/EmailValidationResponse.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/response/EmailValidationResponse.java
@@ -1,0 +1,17 @@
+package com.zoopi.controller.member.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailValidationResponse {
+
+	private String email;
+	private boolean isValidated;
+}

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -19,16 +19,17 @@ jar {
  * 따라서 compile(Gradle 7.0 미만) 혹은 api(Gradle 7.0 이상)으로 의존성을 추가해야 한다.
  */
 dependencies {
-    api 'org.springframework.boot:spring-boot-starter-validation'
-    api 'org.springframework.boot:spring-boot-starter-web'
-    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'com.querydsl:querydsl-jpa'
+
     api 'org.springframework.boot:spring-boot-starter-security'
     api 'org.springframework.boot:spring-boot-starter-websocket'
+    api 'org.springframework.boot:spring-boot-starter-validation'
+    api 'org.springframework.boot:spring-boot-starter-web'
 
+    testImplementation 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
-
-    // Querydsl
-    api 'com.querydsl:querydsl-jpa'
 }
 
 // QClass 생성 위치

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/JoinType.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/JoinType.java
@@ -1,0 +1,5 @@
+package com.zoopi.domain.member.entity;
+
+public enum JoinType {
+	EMAIL, KAKAO, NAVER
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/Member.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/Member.java
@@ -1,0 +1,67 @@
+package com.zoopi.domain.member.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// TODO
+//  - 통신사 여부
+//  - 프로필 이미지
+
+@Entity
+@Getter
+@Table(name = "members")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	@Column(name = "member_email", unique = true)
+	private String email;
+
+	@Column(name = "member_password")
+	private String password;
+
+	@Column(name = "member_name")
+	private String name;
+
+	@Column(name = "member_phone", unique = true)
+	private String phone;
+
+	@CreatedDate
+	@Column(name = "member_create_date")
+	private LocalDateTime createdDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "member_join_type")
+	private JoinType joinType;
+
+	@Builder
+	public Member(String email, String password, String name, String phone, JoinType joinType) {
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.phone = phone;
+		this.joinType = joinType;
+	}
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.zoopi.domain.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zoopi.domain.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByEmail(String email);
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package com.zoopi.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.zoopi.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public boolean validateEmail(String email) {
+		return memberRepository.findByEmail(email).isEmpty();
+	}
+}

--- a/module-domain/src/main/java/com/zoopi/exception/response/ErrorResponse.java
+++ b/module-domain/src/main/java/com/zoopi/exception/response/ErrorResponse.java
@@ -39,6 +39,18 @@ public class ErrorResponse {
 		this.errors = new ArrayList<>();
 	}
 
+	private ErrorResponse(final int status, final String code, final String message, final List<FieldError> errors) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+		this.errors = errors;
+	}
+
+	public static ErrorResponse of(final int status, final String code, final String message,
+		final List<FieldError> errors) {
+		return new ErrorResponse(status, code, message, errors);
+	}
+
 	public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
 		return new ErrorResponse(code, FieldError.of(bindingResult));
 	}
@@ -97,7 +109,12 @@ public class ErrorResponse {
 		private static List<FieldError> of(final Set<ConstraintViolation<?>> constraintViolations) {
 			final List<ConstraintViolation<?>> lists = new ArrayList<>(constraintViolations);
 			return lists.stream()
-				.map(error -> new FieldError(error.getPropertyPath().toString(), "", error.getMessageTemplate()))
+				.map(error -> {
+					final String invalidValue = error.getInvalidValue() == null ? "" : error.getInvalidValue().toString();
+					final int index = error.getPropertyPath().toString().indexOf(".");
+					final String propertyPath = error.getPropertyPath().toString().substring(index + 1);
+					return new FieldError(propertyPath, invalidValue, error.getMessage());
+				})
 				.collect(Collectors.toList());
 		}
 	}

--- a/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,52 @@
+package com.zoopi.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@InjectMocks
+	private MemberService memberService;
+
+	@Test
+	void validateEmail_UniqueEmail_True() throws Exception {
+	    // given
+		final String email = "unique@zoopi.com";
+		doReturn(Optional.empty()).when(memberRepository).findByEmail(email);
+
+	    // when
+		final boolean isValidated = memberService.validateEmail(email);
+
+		// then
+		assertThat(isValidated).isTrue();
+	}
+
+	@Test
+	void validateEmail_DuplicateEmail_False() throws Exception {
+	    // given
+		final String email = "duplicate@zoopi.com";
+		doReturn(Optional.of(mock(Member.class))).when(memberRepository).findByEmail(email);
+
+	    // when
+		final boolean isValidated = memberService.validateEmail(email);
+
+		// then
+		assertThat(isValidated).isFalse();
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'zoopi'
+rootProject.name = 'zoopi-spring-backend'
 include 'module-api'
 include 'module-common'
 include 'module-domain'


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌 Linked Issues
- Resolve: #5 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## 🔎 Change Details
### Member Entity 생성
- id, email, password, name, phone, createdDate, joinType
- 프로필 이미지: 기획문서에는 없으나 디자인에는 존재. 이후 추가
- 통신사: 휴대폰 인증 로직 구현하면서 필요 시 추가
- JoinType: 이메일, 카카오, 네이버 가입 방식 구분 용도

### 이메일 중복 체크 기능 구현
- DB에 해당 이메일을 사용하는 회원이 없는 경우: isValidated = true
- DB에 해당 이메일을 사용하는 회원이 있는 경우: isValidated = false
- 두 결과 모두 200 응답을 전달
- 서비스 단위 테스트 코드 작성

### rootProject.name 수정
- settings.gradle의 rootProject.name이 잘못 되어 있어서 컴포넌트스캔이 제대로 동작하지 않았음

###  ErrorResponse 수정
- **JwtException 핸들링을 위한 ErrorResponse 생성자 추가**
    - 아직 커밋은 안했지만, JwtRequestFilter에서 발생하는 JwtException을 핸들링하기 위한 생성자를 추가 함
- **ConstraintViolationException 핸들링 FieldError 생성자 로직 수정**
    - `@Validated`를 컨트롤러 단위에 추가한 경우, AOP 기반으로 메소드의 요청을 가로채서 유효성 검증을 진행
    - 이 때 발생하는 예외가 ConstraintViolationException이며, 이를 핸들링하는 생성자 로직을 수정 함

### build.gradle, gitignore 수정
- **root**
    - SpringBoot downgrade: Swagger 호환성 문제
- **module-domain**
    - 외부 모듈에서 의존할 필요 없는 의존성 implementation 으로 변경
- **module-api**
    - main 메소드가 존재하므로 bootJar.enabled=false 제거
- **.gitignore**
    - ~/*.properties 제거
    - 프로퍼티 파일을 yml 으로 통일. 이후 properties 파일이 추가될 수 있기 때문에 제거 함

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬 Comment
-

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑 References
- [Are You Using @Valid and @Validated Annotations Wrong?](https://medium.com/javarevisited/are-you-using-valid-and-validated-annotations-wrong-b4a35ac1bca4)

## ✅ Check Lists
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
- [x] merge할 base branch가 올바른지 확인하셨나요?