### PR TITLE
휴대폰 인증 차단 로직, 이메일 회원 가입 API 추가

### DIFF
--- a/module-api/src/main/java/com/zoopi/ZoopiApplication.java
+++ b/module-api/src/main/java/com/zoopi/ZoopiApplication.java
@@ -9,4 +9,5 @@ public class ZoopiApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(ZoopiApplication.class, args);
 	}
+
 }

--- a/module-api/src/main/java/com/zoopi/advice/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/zoopi/advice/GlobalExceptionHandler.java
@@ -117,4 +117,5 @@ public class GlobalExceptionHandler {
 		final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
+
 }

--- a/module-api/src/main/java/com/zoopi/controller/ResultCode.java
+++ b/module-api/src/main/java/com/zoopi/controller/ResultCode.java
@@ -12,6 +12,7 @@ public enum ResultCode {
 	EMAIL_DUPLICATE(200, "R-M002", "이미 사용 중인 이메일입니다."),
 	PHONE_AVAILABLE(200, "R-M003", "사용 가능한 휴대폰 번호입니다."),
 	PHONE_DUPLICATE(200, "R-M004", "이미 사용 중인 휴대폰 번호입니다."),
+	SIGNUP_SUCCESS(200, "R-M005", "회원 가입에 성공하였습니다."),
 
 	// Authentication
 	AUTHENTICATION_CODE_EXPIRED(200, "R-A001", "만료된 인증 코드입니다."),
@@ -19,6 +20,8 @@ public enum ResultCode {
 	AUTHENTICATION_CODE_MATCHED(200, "R-A003", "인증 코드가 일치합니다."),
 	DELETE_ALL_EXPIRED_AUTHENTICATION_CODES(200, "R-A004", "만료된 인증 코드를 모두 제거하였습니다."),
 	SEND_AUTHENTICATION_CODE_SUCCESS(200, "R-A005", "인증 코드 전송에 성공하였습니다."),
+	AUTHENTICATION_KEY_NOT_AUTHENTICATED(200, "R-A006", "인증 확인이 되지 않은 인증 키입니다."),
+	AUTHENTICATION_KEY_EXPIRED(200, "R-A007", "만료된 인증 키입니다."),
 
 	// Ban
 	PHONE_BANNED(200, "R-B001", "인증번호 전송이 제한된 휴대폰 번호입니다. 24시간 후 재시도해 주세요."),
@@ -27,4 +30,5 @@ public enum ResultCode {
 	private final int status;
 	private final String code;
 	private final String message;
+
 }

--- a/module-api/src/main/java/com/zoopi/controller/ResultCode.java
+++ b/module-api/src/main/java/com/zoopi/controller/ResultCode.java
@@ -18,11 +18,10 @@ public enum ResultCode {
 	AUTHENTICATION_CODE_MISMATCHED(200, "R-A002", "인증 코드가 일치하지 않습니다."),
 	AUTHENTICATION_CODE_MATCHED(200, "R-A003", "인증 코드가 일치합니다."),
 	DELETE_ALL_EXPIRED_AUTHENTICATION_CODES(200, "R-A004", "만료된 인증 코드를 모두 제거하였습니다."),
+	SEND_AUTHENTICATION_CODE_SUCCESS(200, "R-A005", "인증 코드 전송에 성공하였습니다."),
 
-
-	// Sms
-	SEND_SMS_SUCCESS(200, "R-S001", "메시지 전송에 성공하였습니다."),
-	SEND_SMS_FAILURE(200, "R-S002", "메시지 전송에 실패하였습니다. 잠시 후 다시 시도해 주세요."),
+	// Ban
+	PHONE_BANNED(200, "R-B001", "인증번호 전송이 제한된 휴대폰 번호입니다. 24시간 후 재시도해 주세요."),
 	;
 
 	private final int status;

--- a/module-api/src/main/java/com/zoopi/controller/ResultResponse.java
+++ b/module-api/src/main/java/com/zoopi/controller/ResultResponse.java
@@ -31,4 +31,5 @@ public class ResultResponse {
 		this.message = resultCode.getMessage();
 		this.data = data;
 	}
+
 }

--- a/module-api/src/main/java/com/zoopi/controller/member/request/AuthenticationCodeCheckRequest.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/request/AuthenticationCodeCheckRequest.java
@@ -28,4 +28,5 @@ public class AuthenticationCodeCheckRequest {
 	@Length(min = 6, max = 6)
 	@ApiModelProperty(value = "인증 코드", required = true, example = "012345")
 	private String authenticationCode;
+
 }

--- a/module-api/src/main/java/com/zoopi/controller/member/request/SignupRequest.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/request/SignupRequest.java
@@ -1,0 +1,46 @@
+package com.zoopi.controller.member.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignupRequest {
+
+	@NotNull
+	@Size(max = 30)
+	@Email
+	private String email;
+
+	@NotNull
+	@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&+=]).*$")
+	private String password;
+
+	@NotNull
+	@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&+=]).*$")
+	private String passwordCheck;
+
+	@NotNull
+	@Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$")
+	private String phone;
+
+	@NotNull
+	@Pattern(regexp = "^[\\da-zA-Z가-힣]{1,10}$")
+	private String name;
+
+	@NotBlank
+	@Size(max = 36)
+	private String authenticationKey;
+
+}

--- a/module-api/src/main/java/com/zoopi/controller/member/response/ValidationResponse.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/response/ValidationResponse.java
@@ -12,4 +12,5 @@ public class ValidationResponse {
 
 	private String value;
 	private boolean isValidated;
+
 }

--- a/module-common/src/main/java/com/zoopi/util/AuthenticationCodeUtils.java
+++ b/module-common/src/main/java/com/zoopi/util/AuthenticationCodeUtils.java
@@ -15,4 +15,5 @@ public class AuthenticationCodeUtils {
 
 		return numStr.toString();
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/config/JpaAuditingConfig.java
+++ b/module-domain/src/main/java/com/zoopi/config/JpaAuditingConfig.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 @Configuration
 public class JpaAuditingConfig {
+
 }

--- a/module-domain/src/main/java/com/zoopi/config/QuerydslConfig.java
+++ b/module-domain/src/main/java/com/zoopi/config/QuerydslConfig.java
@@ -14,4 +14,5 @@ public class QuerydslConfig {
 	public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
 		return new JPAQueryFactory(entityManager);
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/config/RestTemplateConfig.java
+++ b/module-domain/src/main/java/com/zoopi/config/RestTemplateConfig.java
@@ -11,4 +11,5 @@ public class RestTemplateConfig {
 	public RestTemplate restTemplate() {
 		return new RestTemplate();
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/dto/response/AuthenticationResponse.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/dto/response/AuthenticationResponse.java
@@ -14,4 +14,5 @@ public class AuthenticationResponse {
 
 	private String authenticationKey;
 	private LocalDateTime expiredDate;
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/dto/response/AuthenticationResult.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/dto/response/AuthenticationResult.java
@@ -1,5 +1,6 @@
 package com.zoopi.domain.authentication.dto.response;
 
 public enum AuthenticationResult {
-	SUCCESS, EXPIRED, MISMATCHED
+	AUTHENTICATED, NOT_AUTHENTICATED, EXPIRED, MISMATCHED
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Authentication.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Authentication.java
@@ -26,8 +26,8 @@ public class Authentication {
 	@Column(name = "authentication_code")
 	private String code;
 
-	@Column(name = "authentication_value")
-	private String value;
+	@Column(name = "authentication_phone")
+	private String phone;
 
 	@Column(name = "authentication_expire_date")
 	private LocalDateTime expiredDate;

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Authentication.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Authentication.java
@@ -4,18 +4,23 @@ import java.time.LocalDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "authentications")
-@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Authentication {
 
@@ -29,6 +34,22 @@ public class Authentication {
 	@Column(name = "authentication_phone")
 	private String phone;
 
-	@Column(name = "authentication_expire_date")
-	private LocalDateTime expiredDate;
+	@CreatedDate
+	@Column(name = "authentication_create_date")
+	private LocalDateTime createdDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "authentication_status")
+	private AuthenticationStatus status;
+
+	public Authentication(String id, String code, String phone) {
+		this.id = id;
+		this.code = code;
+		this.phone = phone;
+		this.status = AuthenticationStatus.NOT_AUTHENTICATED;
+	}
+
+	public void authenticate() {
+		this.status = AuthenticationStatus.AUTHENTICATED;
+	}
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Authentication.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Authentication.java
@@ -52,4 +52,5 @@ public class Authentication {
 	public void authenticate() {
 		this.status = AuthenticationStatus.AUTHENTICATED;
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/entity/AuthenticationStatus.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/entity/AuthenticationStatus.java
@@ -1,0 +1,7 @@
+package com.zoopi.domain.authentication.entity;
+
+public enum AuthenticationStatus {
+
+	NOT_AUTHENTICATED, AUTHENTICATED
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Ban.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/entity/Ban.java
@@ -1,0 +1,38 @@
+package com.zoopi.domain.authentication.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "bans")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ban {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ban_id")
+	private Long id;
+
+	@Column(name = "ban_phone")
+	private String phone;
+
+	@Column(name = "ban_date")
+	private LocalDateTime bannedDate;
+
+	public Ban(String phone, LocalDateTime bannedDate) {
+		this.phone = phone;
+		this.bannedDate = bannedDate;
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/exception/PasswordMismatchException.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/exception/PasswordMismatchException.java
@@ -1,0 +1,12 @@
+package com.zoopi.domain.authentication.exception;
+
+import com.zoopi.exception.BusinessException;
+import com.zoopi.exception.response.ErrorCode;
+
+public class PasswordMismatchException extends BusinessException {
+
+	public PasswordMismatchException() {
+		super(ErrorCode.PASSWORD_MISMATCHED);
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/repository/AuthenticationRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/repository/AuthenticationRepository.java
@@ -6,11 +6,12 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.zoopi.domain.authentication.entity.Authentication;
+import com.zoopi.domain.authentication.entity.AuthenticationStatus;
 
 public interface AuthenticationRepository extends JpaRepository<Authentication, String> {
 
-	List<Authentication> findAllByExpiredDateBefore(LocalDateTime now);
+	List<Authentication> findAllByStatusAndCreatedDateAfter(AuthenticationStatus status, LocalDateTime date);
 
-	int countByPhoneAndExpiredDateAfter(String phone, LocalDateTime minusMinutes);
+	int countByPhoneAndCreatedDateAfter(String phone, LocalDateTime date);
 
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/repository/AuthenticationRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/repository/AuthenticationRepository.java
@@ -10,4 +10,7 @@ import com.zoopi.domain.authentication.entity.Authentication;
 public interface AuthenticationRepository extends JpaRepository<Authentication, String> {
 
 	List<Authentication> findAllByExpiredDateBefore(LocalDateTime now);
+
+	int countByPhoneAndExpiredDateAfter(String phone, LocalDateTime minusMinutes);
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/repository/BanRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/repository/BanRepository.java
@@ -1,0 +1,13 @@
+package com.zoopi.domain.authentication.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zoopi.domain.authentication.entity.Ban;
+
+public interface BanRepository extends JpaRepository<Ban, Long> {
+
+	Optional<Ban> findByPhone(String phone);
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/service/AuthenticationService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/service/AuthenticationService.java
@@ -125,4 +125,5 @@ public class AuthenticationService {
 			return AuthenticationResult.NOT_AUTHENTICATED;
 		}
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/service/BanService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/service/BanService.java
@@ -1,0 +1,46 @@
+package com.zoopi.domain.authentication.service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.zoopi.domain.authentication.entity.Ban;
+import com.zoopi.domain.authentication.repository.BanRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BanService {
+
+	private final BanRepository banRepository;
+
+	private final long BAN_DAY = 1L;
+
+	@Transactional
+	public boolean isBannedPhone(String phone) {
+		final LocalDateTime now = LocalDateTime.now();
+		final Optional<Ban> banOptional = banRepository.findByPhone(phone);
+
+		if (banOptional.isEmpty()) {
+			return false;
+		} else {
+			final Ban ban = banOptional.get();
+			if (now.isAfter(ban.getBannedDate().plusDays(BAN_DAY))) {
+				banRepository.delete(ban);
+				return false;
+			} else {
+				return true;
+			}
+		}
+	}
+
+	@Transactional
+	public Ban banPhone(String phone) {
+		return banRepository.save(new Ban(phone, LocalDateTime.now()));
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/JoinType.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/JoinType.java
@@ -2,4 +2,5 @@ package com.zoopi.domain.member.entity;
 
 public enum JoinType {
 	EMAIL, KAKAO, NAVER
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/Member.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/Member.java
@@ -21,7 +21,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 // TODO
-//  - 통신사 여부
 //  - 프로필 이미지
 
 @Entity
@@ -64,4 +63,5 @@ public class Member {
 		this.phone = phone;
 		this.joinType = joinType;
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberRepository.java
@@ -11,4 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
 
 	Optional<Member> findByPhone(String phone);
+
 }

--- a/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
@@ -1,8 +1,11 @@
 package com.zoopi.domain.member.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.zoopi.domain.member.entity.JoinType;
+import com.zoopi.domain.member.entity.Member;
 import com.zoopi.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	public boolean validateEmail(String email) {
 		return memberRepository.findByEmail(email).isEmpty();
@@ -21,4 +25,10 @@ public class MemberService {
 	public boolean validatePhone(String phone) {
 		return memberRepository.findByPhone(phone).isEmpty();
 	}
+
+	@Transactional
+	public Member createMember(String email, String phone, String name, String password) {
+		return memberRepository.save(new Member(email, passwordEncoder.encode(password), name, phone, JoinType.EMAIL));
+	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/exception/BusinessException.java
+++ b/module-domain/src/main/java/com/zoopi/exception/BusinessException.java
@@ -29,4 +29,5 @@ public class BusinessException extends RuntimeException {
 		this.errors = errors;
 		this.errorCode = errorCode;
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/exception/EntityAlreadyExistException.java
+++ b/module-domain/src/main/java/com/zoopi/exception/EntityAlreadyExistException.java
@@ -7,4 +7,5 @@ public class EntityAlreadyExistException extends BusinessException {
 	public EntityAlreadyExistException(ErrorCode errorCode) {
 		super(errorCode);
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/exception/EntityNotFoundException.java
+++ b/module-domain/src/main/java/com/zoopi/exception/EntityNotFoundException.java
@@ -7,4 +7,5 @@ public class EntityNotFoundException extends BusinessException {
 	public EntityNotFoundException(ErrorCode errorCode) {
 		super(errorCode);
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/exception/InvalidArgumentException.java
+++ b/module-domain/src/main/java/com/zoopi/exception/InvalidArgumentException.java
@@ -10,4 +10,5 @@ public class InvalidArgumentException extends BusinessException {
 	public InvalidArgumentException(List<ErrorResponse.FieldError> errors) {
 		super(ErrorCode.INPUT_VALUE_INVALID, errors);
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/exception/response/ErrorResponse.java
+++ b/module-domain/src/main/java/com/zoopi/exception/response/ErrorResponse.java
@@ -117,5 +117,7 @@ public class ErrorResponse {
 				})
 				.collect(Collectors.toList());
 		}
+
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/infra/sms/NaverSensClient.java
+++ b/module-domain/src/main/java/com/zoopi/infra/sms/NaverSensClient.java
@@ -72,9 +72,8 @@ public class NaverSensClient implements SmsClient {
 			return response.getStatusCode().is2xxSuccessful();
 		} catch (Exception e) {
 			e.printStackTrace();
+			throw new RuntimeException(e.getMessage());
 		}
-
-		return false;
 	}
 
 	private String getSignature(String time) throws NoSuchAlgorithmException, InvalidKeyException {
@@ -108,6 +107,7 @@ public class NaverSensClient implements SmsClient {
 			this.content = content;
 			this.messages = messages;
 		}
+
 	}
 
 	@Getter
@@ -119,6 +119,7 @@ public class NaverSensClient implements SmsClient {
 		private String requestTime;
 		private String statusCode;
 		private String statusName;
+
 	}
 
 	@Getter
@@ -128,5 +129,7 @@ public class NaverSensClient implements SmsClient {
 
 		private String to;
 		private String content;
+
 	}
+
 }

--- a/module-domain/src/main/java/com/zoopi/infra/sms/SmsClient.java
+++ b/module-domain/src/main/java/com/zoopi/infra/sms/SmsClient.java
@@ -3,4 +3,5 @@ package com.zoopi.infra.sms;
 public interface SmsClient {
 
 	boolean sendSms(String phone, String authenticationCode);
+
 }

--- a/module-domain/src/test/java/com/zoopi/domain/authentication/service/AuthenticationServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/authentication/service/AuthenticationServiceTest.java
@@ -5,18 +5,23 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.zoopi.domain.authentication.dto.response.AuthenticationResponse;
 import com.zoopi.domain.authentication.dto.response.AuthenticationResult;
 import com.zoopi.domain.authentication.entity.Authentication;
+import com.zoopi.domain.authentication.entity.AuthenticationStatus;
+import com.zoopi.domain.authentication.exception.PasswordMismatchException;
 import com.zoopi.domain.authentication.repository.AuthenticationRepository;
 import com.zoopi.infra.sms.SmsClient;
 import com.zoopi.util.AuthenticationCodeUtils;
@@ -34,7 +39,7 @@ class AuthenticationServiceTest {
 	private AuthenticationService authenticationService;
 
 	@Test
-	void sendAuthenticationCode_phone_sendSmsSuccess() throws Exception {
+	void sendAuthenticationCode_Phone_SendSmsSuccess() throws Exception {
 		// given
 		final String phone = "01012345678";
 		final String authenticationCode = AuthenticationCodeUtils.generateRandomAuthenticationCode(6);
@@ -48,12 +53,15 @@ class AuthenticationServiceTest {
 	}
 
 	@Test
-	void createAuthentication_codeAndPhone_success() throws Exception {
+	void createAuthentication_CodeAndPhone_Success() throws Exception {
 		// given
 		final String phone = "01012345678";
 		final String authenticationCode = AuthenticationCodeUtils.generateRandomAuthenticationCode(6);
+		final Authentication authentication = new Authentication(UUID.randomUUID().toString(), authenticationCode,
+			phone);
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now());
 		doReturn(Optional.empty()).when(authenticationRepository).findById(any(String.class));
-		doReturn(mock(Authentication.class)).when(authenticationRepository).save(any(Authentication.class));
+		doReturn(authentication).when(authenticationRepository).save(any(Authentication.class));
 
 		// when
 		final AuthenticationResponse authenticationResponse = authenticationService.createAuthentication(phone,
@@ -68,7 +76,7 @@ class AuthenticationServiceTest {
 		// given
 		final String phone = "01012345678";
 		doReturn(3).when(authenticationRepository)
-			.countByPhoneAndExpiredDateAfter(any(String.class), any(LocalDateTime.class));
+			.countByPhoneAndCreatedDateAfter(any(String.class), any(LocalDateTime.class));
 
 		// when
 		final int count = authenticationService.getCountOfAuthentication(phone);
@@ -78,7 +86,7 @@ class AuthenticationServiceTest {
 	}
 
 	@Test
-	void checkAuthenticationCode_nonexistentKey_expired() throws Exception {
+	void checkAuthenticationCode_NonexistentKey_Expired() throws Exception {
 		// given
 		final String authenticationKey = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76";
 		final String authenticationCode = "123456";
@@ -94,13 +102,13 @@ class AuthenticationServiceTest {
 	}
 
 	@Test
-	void checkAuthenticationCode_expiredCode_expired() throws Exception {
+	void checkAuthenticationCode_ExpiredCode_Expired() throws Exception {
 		// given
 		final String authenticationKey = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76";
 		final String authenticationCode = "123456";
 		final String phone = "01012345678";
-		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone,
-			LocalDateTime.now().minusMinutes(1));
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone);
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now().minusMinutes(5L));
 		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
 
 		// when
@@ -112,13 +120,13 @@ class AuthenticationServiceTest {
 	}
 
 	@Test
-	void checkAuthenticationCode_matchedCodeAndMyPhone_success() throws Exception {
+	void checkAuthenticationCode_MatchedCodeAndMyPhone_Success() throws Exception {
 		// given
 		final String authenticationKey = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76";
 		final String authenticationCode = "123456";
 		final String phone = "01012345678";
-		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone,
-			LocalDateTime.now().plusMinutes(5));
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone);
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now());
 		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
 
 		// when
@@ -126,18 +134,18 @@ class AuthenticationServiceTest {
 			authenticationCode, phone, authenticationKey);
 
 		// then
-		assertThat(result).isEqualTo(AuthenticationResult.SUCCESS);
+		assertThat(result).isEqualTo(AuthenticationResult.AUTHENTICATED);
 	}
 
 	@Test
-	void checkAuthenticationCode_mismatchedCode_mismatched() throws Exception {
+	void checkAuthenticationCode_MismatchedCode_Mismatched() throws Exception {
 		// given
 		final String authenticationKey = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76";
 		final String authenticationCode = "123456";
 		final String wrongAuthenticationCode = "634262";
 		final String phone = "01012345678";
-		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone,
-			LocalDateTime.now().plusMinutes(5));
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone);
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now());
 		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
 
 		// when
@@ -149,14 +157,14 @@ class AuthenticationServiceTest {
 	}
 
 	@Test
-	void checkAuthenticationCode_matchedCodeAndNotMyPhone_mismatched() throws Exception {
+	void checkAuthenticationCode_MatchedCodeAndNotMyPhone_Mismatched() throws Exception {
 		// given
 		final String authenticationKey = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76";
 		final String authenticationCode = "123456";
 		final String phone = "01012345678";
 		final String otherPhone = "01012341234";
-		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, otherPhone,
-			LocalDateTime.now().plusMinutes(5));
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, otherPhone);
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now());
 		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
 
 		// when
@@ -168,16 +176,128 @@ class AuthenticationServiceTest {
 	}
 
 	@Test
-	void deleteExpiredAuthenticationCodes_success() throws Exception {
+	void deleteExpiredAuthenticationCodes_Success() throws Exception {
 		// given
-		doReturn(List.of(mock(Authentication.class), mock(Authentication.class)))
-			.when(authenticationRepository).findAllByExpiredDateBefore(any(LocalDateTime.class));
-		doNothing().when(authenticationRepository).deleteAllInBatch(any(List.class));
+		doReturn(new ArrayList<>())
+			.when(authenticationRepository)
+			.findAllByStatusAndCreatedDateAfter(any(AuthenticationStatus.class), any(LocalDateTime.class));
 
 		// when
-		authenticationService.deleteExpiredAuthenticationCodes();
+		final boolean result = authenticationService.deleteExpiredAuthenticationCodes();
 
 		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	void validatePassword_MatchedPassword_True() throws Exception {
+		// given
+		final String password = "qlalfqjsgh1!";
+		final String passwordCheck = "qlalfqjsgh1!";
+
+		// when
+		final boolean result = authenticationService.validatePassword(password, passwordCheck);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	void validatePassword_MismatchedPassword_ExceptionThrown() throws Exception {
+		// given
+		final String password = "qlalfqjsgh1!";
+		final String passwordCheck = "qlalfqjsgh1@";
+
+		// when
+		final Executable executable = () -> authenticationService.validatePassword(password, passwordCheck);
+
+		// then
+		assertThrows(PasswordMismatchException.class, executable);
+	}
+
+	@Test
+	void validateAuthenticationKey_NonExistentKey_Expired() throws Exception {
+		// given
+		final String phone = "01012341234";
+		final String authenticationKey = UUID.randomUUID().toString();
+		doReturn(Optional.empty()).when(authenticationRepository).findById(any(String.class));
+
+		// when
+		final AuthenticationResult result = authenticationService.validateAuthenticationKey(phone, authenticationKey);
+
+		// then
+		assertThat(result).isEqualTo(AuthenticationResult.EXPIRED);
+	}
+
+	@Test
+	void validateAuthenticationKey_ExpiredKey_Expired() throws Exception {
+		// given
+		final String phone = "01012341234";
+		final String authenticationKey = UUID.randomUUID().toString();
+		final String authenticationCode = "123456";
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone);
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now().minusMinutes(60L));
+		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
+
+		// when
+		final AuthenticationResult result = authenticationService.validateAuthenticationKey(phone, authenticationKey);
+
+		// then
+		assertThat(result).isEqualTo(AuthenticationResult.EXPIRED);
+	}
+
+	@Test
+	void validateAuthenticationKey_AuthenticatedKeyAndMyPhone_Authenticated() throws Exception {
+		// given
+		final String phone = "01012341234";
+		final String authenticationKey = UUID.randomUUID().toString();
+		final String authenticationCode = "123456";
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone);
+		authentication.authenticate();
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now().minusMinutes(10L));
+		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
+
+		// when
+		final AuthenticationResult result = authenticationService.validateAuthenticationKey(phone, authenticationKey);
+
+		// then
+		assertThat(result).isEqualTo(AuthenticationResult.AUTHENTICATED);
+	}
+
+	@Test
+	void validateAuthenticationKey_NotAuthenticatedKey_NotAuthenticated() throws Exception {
+		// given
+		final String phone = "01012341234";
+		final String authenticationKey = UUID.randomUUID().toString();
+		final String authenticationCode = "123456";
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, phone);
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now().minusMinutes(10L));
+		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
+
+		// when
+		final AuthenticationResult result = authenticationService.validateAuthenticationKey(phone, authenticationKey);
+
+		// then
+		assertThat(result).isEqualTo(AuthenticationResult.NOT_AUTHENTICATED);
+	}
+
+	@Test
+	void validateAuthenticationKey_NotMyPhone_NotAuthenticated() throws Exception {
+		// given
+		final String phone = "01012341234";
+		final String otherPhone = "01034341212";
+		final String authenticationKey = UUID.randomUUID().toString();
+		final String authenticationCode = "123456";
+		final Authentication authentication = new Authentication(authenticationKey, authenticationCode, otherPhone);
+		authentication.authenticate();
+		ReflectionTestUtils.setField(authentication, "createdDate", LocalDateTime.now().minusMinutes(10L));
+		doReturn(Optional.of(authentication)).when(authenticationRepository).findById(any(String.class));
+
+		// when
+		final AuthenticationResult result = authenticationService.validateAuthenticationKey(phone, authenticationKey);
+
+		// then
+		assertThat(result).isEqualTo(AuthenticationResult.NOT_AUTHENTICATED);
 	}
 
 }

--- a/module-domain/src/test/java/com/zoopi/domain/authentication/service/BanServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/authentication/service/BanServiceTest.java
@@ -1,0 +1,82 @@
+package com.zoopi.domain.authentication.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.zoopi.domain.authentication.entity.Ban;
+import com.zoopi.domain.authentication.repository.BanRepository;
+
+@ExtendWith(MockitoExtension.class)
+class BanServiceTest {
+
+	@Mock
+	private BanRepository banRepository;
+
+	@InjectMocks
+	private BanService banService;
+
+	@Test
+	void isBannedPhone_notBannedPhone_false() throws Exception {
+	    // given
+		final String phone = "01012341234";
+		doReturn(Optional.empty()).when(banRepository).findByPhone(any(String.class));
+
+	    // when
+		final boolean isBanned = banService.isBannedPhone(phone);
+
+		// then
+		assertThat(isBanned).isFalse();
+	}
+
+	@Test
+	void isBannedPhone_bannedPhone_true() throws Exception {
+	    // given
+		final String phone = "01012341234";
+		final Ban ban = new Ban(phone, LocalDateTime.now());
+		doReturn(Optional.of(ban)).when(banRepository).findByPhone(any(String.class));
+
+	    // when
+		final boolean isBanned = banService.isBannedPhone(phone);
+
+		// then
+		assertThat(isBanned).isTrue();
+	}
+
+	@Test
+	void isBannedPhone_justFreedPhone_false() throws Exception {
+	    // given
+		final String phone = "01012341234";
+		final Ban ban = new Ban(phone, LocalDateTime.now().minusDays(1L));
+		doReturn(Optional.of(ban)).when(banRepository).findByPhone(any(String.class));
+
+	    // when
+		final boolean isBanned = banService.isBannedPhone(phone);
+
+		// then
+		assertThat(isBanned).isFalse();
+	}
+
+	@Test
+	void banPhone_phone_ban() throws Exception {
+	    // given
+		final String phone = "01012341234";
+		doReturn(new Ban(phone, LocalDateTime.now())).when(banRepository).save(any(Ban.class));
+
+	    // when
+		final Ban ban = banService.banPhone(phone);
+
+		// then
+		assertThat(ban.getPhone()).isEqualTo(phone);
+	}
+
+}

--- a/module-domain/src/test/java/com/zoopi/domain/authentication/service/BanServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/authentication/service/BanServiceTest.java
@@ -26,7 +26,7 @@ class BanServiceTest {
 	private BanService banService;
 
 	@Test
-	void isBannedPhone_notBannedPhone_false() throws Exception {
+	void isBannedPhone_NotBannedPhone_False() throws Exception {
 	    // given
 		final String phone = "01012341234";
 		doReturn(Optional.empty()).when(banRepository).findByPhone(any(String.class));
@@ -39,7 +39,7 @@ class BanServiceTest {
 	}
 
 	@Test
-	void isBannedPhone_bannedPhone_true() throws Exception {
+	void isBannedPhone_BannedPhone_True() throws Exception {
 	    // given
 		final String phone = "01012341234";
 		final Ban ban = new Ban(phone, LocalDateTime.now());
@@ -53,7 +53,7 @@ class BanServiceTest {
 	}
 
 	@Test
-	void isBannedPhone_justFreedPhone_false() throws Exception {
+	void isBannedPhone_JustFreedPhone_False() throws Exception {
 	    // given
 		final String phone = "01012341234";
 		final Ban ban = new Ban(phone, LocalDateTime.now().minusDays(1L));
@@ -67,7 +67,7 @@ class BanServiceTest {
 	}
 
 	@Test
-	void banPhone_phone_ban() throws Exception {
+	void banPhone_Phone_Ban() throws Exception {
 	    // given
 		final String phone = "01012341234";
 		doReturn(new Ban(phone, LocalDateTime.now())).when(banRepository).save(any(Ban.class));

--- a/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.zoopi.domain.member.entity.JoinType;
 import com.zoopi.domain.member.entity.Member;
 import com.zoopi.domain.member.repository.MemberRepository;
 
@@ -20,6 +22,9 @@ class MemberServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
 
 	@InjectMocks
 	private MemberService memberService;
@@ -75,4 +80,22 @@ class MemberServiceTest {
 		// then
 		assertThat(isValidated).isFalse();
 	}
+
+	@Test
+	void createMember_EmailAndPhoneAndNameAndPassword_SuccessToSave() throws Exception {
+	    // given
+		final String email = "zoopi@gmail.com";
+		final String phone = "01012341234";
+		final String name = "주피";
+		final String password = "qlalfqjsgh1!";
+		final Member member = new Member(email, password, name, phone, JoinType.EMAIL);
+		doReturn(member).when(memberRepository).save(any(Member.class));
+
+	    // when
+		final Member savedMember = memberService.createMember(email, phone, name, password);
+
+		// then
+		assertThat(member).isEqualTo(savedMember);
+	}
+
 }

--- a/module-domain/src/test/java/com/zoopi/infra/sms/NaverSensClientTest.java
+++ b/module-domain/src/test/java/com/zoopi/infra/sms/NaverSensClientTest.java
@@ -23,7 +23,7 @@ class NaverSensClientTest {
 
 	@Test
 	@Disabled
-	void sendSms_phoneAndContent_true() throws Exception {
+	void sendSms_PhoneAndContent_True() throws Exception {
 	    // given
 		final String content = "테스트";
 
@@ -33,4 +33,5 @@ class NaverSensClientTest {
 		// then
 		assertThat(result).isTrue();
 	}
+
 }


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌 Linked Issues
- Resolve #9 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## 🔎 Change Details
### NaverSensClient 로직 수정
- api 호출 과정에서 예외 발생 시, 500 응답 생성
- 기존에는 200 응답을 전달했지만, 서버에서 문제가 발생한 것이므로 500 응답이 더 적절하다고 생각하였음

### Ban 엔티티 생성
- 휴대폰 인증 번호 요청이 차단된 번호와 차단된 날짜 정보를 저장함

### 휴대폰 본인 인증 문자 전송 API: 인증 요청 차단 로직 추가
- 5분 이내 5회 이상 요청한 경우, 해당 휴대폰 번호는 24시간 동안 인증 요청이 불가능

### AuthenticationService 리팩토링
- sendAuthenticationCode 메소드에 많은 역할이 존재하여 여러 메소드로 세분화 함.
- 인증 코드 유효 시간 이내로 요청한 인증 엔티티 수를 반환하는 메소드 추가.
- 값 파라미터를 의미 있는 변수로 추출
- Authentication 필드 네이밍 변경(value -> phone)

### Authentication 엔티티 수정
- expiredDate -> createdDate 변경, @CreatedDate 적용
- AuthenticationStatus 추가: 인증 확인 여부
- authenticate() 메소드 추가: 인증 확인 시 호출

### 이메일 회원 가입 API 추가
> - 비밀번호 패턴: 영문자, 숫자, 특수문자 3가지 조합 필수 10 ~ 20자
> - 특수 문자: !@#$%^&+=
#### 과정
1. (비밀번호, 비밀번호 확인) 일치 여부 검사
    - 불일치한 경우 예외 throw (400 응답)
    - 프론트단에서 먼저 일치 여부 검사를 한 다음 API를 호출해야 함
2. 이메일 유효성 체크
    - 회원 가입 과정에서 다른 유저가 먼저 해당 이메일로 가입한 경우 방지
3. 휴대폰 번호 유효성 체크
    - 회원 가입 과정에서 다른 유저가 먼저 해당 휴대폰으로 가입한 경우 방지
4. 인증 키 유효성 체크
    - 아래의 상황인 경우에 유효하다고 판단
    - DB에 인증 키 존재 & 인증 요청 후 30분이 지나지 않은 상태 & 인증한 휴대폰이 본인 휴대폰인 경우
5. 회원 생성 -> DB 저장

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬 Comment
-

<!--
✅ 참고한 문서가 있다면 공유해 주세요.
-->
## 📑 References
- 

## ✅ Check Lists
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
- [x] merge할 base branch가 올바른지 확인하셨나요?
