### PR TITLE
로그인 API 및 OAuth2 로그인 로직 추가

### DIFF
--- a/module-api/src/main/java/com/zoopi/controller/ResultCode.java
+++ b/module-api/src/main/java/com/zoopi/controller/ResultCode.java
@@ -14,6 +14,8 @@ public enum ResultCode {
 	PHONE_DUPLICATE(200, "R-M004", "이미 사용 중인 휴대폰 번호입니다."),
 	SIGN_UP_SUCCESS(200, "R-M005", "회원 가입에 성공하였습니다."),
 	SIGN_IN_SUCCESS(200, "R-M006", "로그인에 성공하였습니다."),
+	MEMBER_PASSWORD_MISMATCHED(200, "R-M007", "회원 비밀번호가 일치하지 않습니다."),
+	MEMBER_USERNAME_NONEXISTENT(200, "R-M008", "회원 아이디가 올바르지 않습니다."),
 
 	// Authentication
 	AUTHENTICATION_CODE_EXPIRED(200, "R-A001", "만료된 인증 코드입니다."),

--- a/module-api/src/main/java/com/zoopi/controller/ResultCode.java
+++ b/module-api/src/main/java/com/zoopi/controller/ResultCode.java
@@ -12,7 +12,8 @@ public enum ResultCode {
 	EMAIL_DUPLICATE(200, "R-M002", "이미 사용 중인 이메일입니다."),
 	PHONE_AVAILABLE(200, "R-M003", "사용 가능한 휴대폰 번호입니다."),
 	PHONE_DUPLICATE(200, "R-M004", "이미 사용 중인 휴대폰 번호입니다."),
-	SIGNUP_SUCCESS(200, "R-M005", "회원 가입에 성공하였습니다."),
+	SIGN_UP_SUCCESS(200, "R-M005", "회원 가입에 성공하였습니다."),
+	SIGN_IN_SUCCESS(200, "R-M006", "로그인에 성공하였습니다."),
 
 	// Authentication
 	AUTHENTICATION_CODE_EXPIRED(200, "R-A001", "만료된 인증 코드입니다."),

--- a/module-api/src/main/java/com/zoopi/controller/member/MemberAuthController.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/MemberAuthController.java
@@ -19,12 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 import com.zoopi.controller.ResultCode;
 import com.zoopi.controller.ResultResponse;
 import com.zoopi.controller.member.request.AuthenticationCodeCheckRequest;
+import com.zoopi.controller.member.request.SigninRequest;
 import com.zoopi.controller.member.request.SignupRequest;
 import com.zoopi.controller.member.response.ValidationResponse;
+import com.zoopi.domain.authentication.dto.JwtDto;
 import com.zoopi.domain.authentication.dto.response.AuthenticationResponse;
 import com.zoopi.domain.authentication.dto.response.AuthenticationResult;
 import com.zoopi.domain.authentication.service.AuthenticationService;
 import com.zoopi.domain.authentication.service.BanService;
+import com.zoopi.domain.member.entity.JoinType;
 import com.zoopi.domain.member.service.MemberService;
 import com.zoopi.util.AuthenticationCodeUtils;
 
@@ -82,6 +85,7 @@ public class MemberAuthController {
 		return ResponseEntity.ok(ResultResponse.of(resultCode, response));
 	}
 
+	// TODO: 비밀번호 찾기 API와 독립적으로 문자 전송 밴 처리
 	@ApiOperation(value = "휴대폰 본인 인증 문자 전송")
 	@ApiImplicitParam(name = "phone", value = "휴대폰 번호", required = true, example = "01012345678")
 	@PostMapping("/phone/send")
@@ -157,9 +161,19 @@ public class MemberAuthController {
 			return ResponseEntity.ok(ResultResponse.of(AUTHENTICATION_KEY_NOT_AUTHENTICATED, response));
 		}
 
-		memberService.createMember(request.getEmail(), request.getPhone(), request.getName(), request.getPassword());
+		memberService.createMember(request.getEmail(), request.getPhone(), request.getName(), request.getPassword(),
+			JoinType.EMAIL);
 
-		return ResponseEntity.ok(ResultResponse.of(SIGNUP_SUCCESS));
+		return ResponseEntity.ok(ResultResponse.of(SIGN_UP_SUCCESS));
+	}
+
+	// TODO: RefreshToken -> Cookie 저장
+	@ApiOperation(value = "이메일 로그인")
+	@PostMapping("/signin/email")
+	public ResponseEntity<ResultResponse> signinByEmail(@Valid @RequestBody SigninRequest request) {
+		final JwtDto jwtDto = memberService.signin(request.getEmail(), request.getPassword());
+
+		return ResponseEntity.ok(ResultResponse.of(SIGN_IN_SUCCESS, jwtDto));
 	}
 
 }

--- a/module-api/src/main/java/com/zoopi/controller/member/request/SigninRequest.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/request/SigninRequest.java
@@ -1,0 +1,29 @@
+package com.zoopi.controller.member.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SigninRequest {
+
+	@NotNull
+	@Size(max = 30)
+	@Email
+	private String email;
+
+	@Size(max = 30)
+	@NotBlank
+	private String password;
+
+}

--- a/module-api/src/main/java/com/zoopi/controller/member/request/SignupRequest.java
+++ b/module-api/src/main/java/com/zoopi/controller/member/request/SignupRequest.java
@@ -24,11 +24,11 @@ public class SignupRequest {
 	private String email;
 
 	@NotNull
-	@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&+=]).*$")
+	@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
 	private String password;
 
 	@NotNull
-	@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&+=]).*$")
+	@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
 	private String passwordCheck;
 
 	@NotNull

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.querydsl:querydsl-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     api 'org.springframework.boot:spring-boot-starter-security'
     api 'org.springframework.boot:spring-boot-starter-websocket'

--- a/module-domain/src/main/java/com/zoopi/config/security/CustomAccessDeniedHandler.java
+++ b/module-domain/src/main/java/com/zoopi/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.zoopi.config.security;
+
+import static com.zoopi.exception.response.ErrorCode.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoopi.exception.response.ErrorResponse;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		try (OutputStream os = response.getOutputStream()) {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.writeValue(os, ErrorResponse.of(INSUFFICIENT_AUTHORITY));
+			os.flush();
+		}
+
+		response.setStatus(HttpStatus.FORBIDDEN.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/config/security/CustomAuthenticationEntryPoint.java
+++ b/module-domain/src/main/java/com/zoopi/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,53 @@
+package com.zoopi.config.security;
+
+import static com.zoopi.exception.response.ErrorCode.*;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoopi.exception.InvalidRequestHeaderException;
+import com.zoopi.exception.response.ErrorResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) {
+		final Exception exception = (Exception)request.getAttribute("exception");
+		final ObjectMapper objectMapper = new ObjectMapper();
+		final ErrorResponse errorResponse;
+
+		if (exception instanceof InvalidRequestHeaderException) {
+			final List<ErrorResponse.FieldError> errors = ((InvalidRequestHeaderException)exception).getErrors();
+			errorResponse = ErrorResponse.of(AUTHENTICATION_FAILURE, errors);
+		} else {
+			final int status = AUTHENTICATION_FAILURE.getStatus();
+			final String code = AUTHENTICATION_FAILURE.getCode();
+			final String message = exception != null ? exception.getMessage() : AUTHENTICATION_FAILURE.getMessage();
+			errorResponse = ErrorResponse.of(status, code, message, new ArrayList<>());
+		}
+
+		try (OutputStream os = response.getOutputStream()) {
+			objectMapper.writeValue(os, errorResponse);
+			os.flush();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/config/security/PasswordEncoderConfig.java
+++ b/module-domain/src/main/java/com/zoopi/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,21 @@
+package com.zoopi.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+	/**
+	 * @since Spring Security 5.0
+	 * @return {@link BCryptPasswordEncoder} - Default
+	 */
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/config/security/WebSecurityConfig.java
+++ b/module-domain/src/main/java/com/zoopi/config/security/WebSecurityConfig.java
@@ -1,0 +1,93 @@
+package com.zoopi.config.security;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.zoopi.config.security.oauth2.CustomOAuth2UserService;
+import com.zoopi.config.security.oauth2.OAuth2SuccessHandler;
+import com.zoopi.filter.JwtRequestFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+	private final JwtRequestFilter requestFilter;
+	private final CustomAccessDeniedHandler accessDeniedHandler;
+	private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+	private final OAuth2SuccessHandler oAuth2SuccessHandler;
+	private final CustomOAuth2UserService oAuth2UserService;
+
+	private static final String[] AUTH_WHITELIST = {"/v2/api-docs", "/configuration/ui", "/swagger-resources/**",
+		"/configuration/security", "/swagger-ui.html/**", "/webjars/**", "/swagger/**"};
+
+	@Override
+	public void configure(WebSecurity web) {
+		web.ignoring().antMatchers(AUTH_WHITELIST);
+		web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+	}
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+			.csrf().disable()
+			.formLogin().disable()
+			.httpBasic().disable()
+			.logout().disable()
+			.cors().configurationSource(configurationSource())
+			.and()
+
+			.exceptionHandling()
+			.accessDeniedHandler(accessDeniedHandler)
+			.authenticationEntryPoint(authenticationEntryPoint)
+			.and()
+
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+
+			.authorizeRequests()
+			.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+			.antMatchers("/auth/**", "/oauth2/**").permitAll()
+			.anyRequest().authenticated()
+			.and()
+
+			.oauth2Login()
+			.redirectionEndpoint().baseUri("/oauth2/callback/*")
+			.and()
+
+			.successHandler(oAuth2SuccessHandler)
+			.userInfoEndpoint().userService(oAuth2UserService)
+		;
+
+		http.addFilterBefore(requestFilter, UsernamePasswordAuthenticationFilter.class);
+	}
+
+	@Bean
+	public CorsConfigurationSource configurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.addAllowedOriginPattern("*");
+		configuration.addAllowedHeader("*");
+		configuration.addAllowedMethod("*");
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+
+		return source;
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/config/security/oauth2/CustomOAuth2UserService.java
+++ b/module-domain/src/main/java/com/zoopi/config/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,89 @@
+package com.zoopi.config.security.oauth2;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+import com.zoopi.domain.member.entity.JoinType;
+import com.zoopi.domain.member.entity.MemberAuthority;
+import com.zoopi.domain.member.entity.oauth2.KakaoAccount;
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.oauth2.NaverAccount;
+import com.zoopi.domain.member.repository.oauth2.KakaoAccountRepository;
+import com.zoopi.domain.member.repository.oauth2.NaverAccountRepository;
+import com.zoopi.domain.member.service.MemberAuthorityService;
+import com.zoopi.domain.member.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	private final MemberService memberService;
+	private final MemberAuthorityService memberAuthorityService;
+	private final KakaoAccountRepository kakaoAccountRepository;
+	private final NaverAccountRepository naverAccountRepository;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+		final OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+
+		final String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		final String userNameAttributeName = userRequest.getClientRegistration()
+			.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+		final OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(registrationId, userNameAttributeName,
+			oAuth2User.getAttributes());
+		final Long id = Long.valueOf(userNameAttributeName);
+
+		final boolean isFirstLogin;
+		if (registrationId.equals(OAuth2Attributes.KAKAO)) {
+			isFirstLogin = kakaoAccountRepository.findById(id).isEmpty();
+		} else {
+			isFirstLogin = naverAccountRepository.findById(id).isEmpty();
+		}
+
+		final List<SimpleGrantedAuthority> authorities;
+		final String email = oAuth2Attributes.getEmail();
+		final String nickname = oAuth2Attributes.getNickname();
+		if (isFirstLogin) {
+			final Member member = signup(registrationId, id, email, nickname);
+			authorities = memberAuthorityService.getMemberAuthorities(member).stream()
+				.map(MemberAuthority::getType)
+				.map(Enum::name)
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
+		} else {
+			authorities = memberAuthorityService.getMemberAuthorities(email).stream()
+				.map(MemberAuthority::getType)
+				.map(Enum::name)
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
+		}
+
+		return new DefaultOAuth2User(authorities, oAuth2Attributes.convertToMap(), oAuth2Attributes.getAttributeKey());
+	}
+
+	private Member signup(String provider, Long id, String email, String nickname) {
+		final Member member;
+		if (provider.equals(OAuth2Attributes.KAKAO)) {
+			member = memberService.createMember(email, "", nickname, "", JoinType.KAKAO);
+			kakaoAccountRepository.save(new KakaoAccount(id, member));
+		} else {
+			member = memberService.createMember(email, "", nickname, "", JoinType.NAVER);
+			naverAccountRepository.save(new NaverAccount(id, member));
+		}
+		return member;
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/config/security/oauth2/OAuth2Attributes.java
+++ b/module-domain/src/main/java/com/zoopi/config/security/oauth2/OAuth2Attributes.java
@@ -1,0 +1,72 @@
+package com.zoopi.config.security.oauth2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OAuth2Attributes {
+
+	public static final String KAKAO = "kakao";
+	public static final String NAVER = "naver";
+
+	private Map<String, Object> attributes;
+	private String provider;
+	private String attributeKey;
+	private String nickname;
+	private String email;
+
+	public static OAuth2Attributes of(String provider, String attributeKey, Map<String, Object> attributes) {
+		if (provider.equals(KAKAO)) {
+			return ofKakao(provider, attributeKey, attributes);
+		} else {
+			return ofNaver(provider, attributeKey, attributes);
+		}
+	}
+
+	private static OAuth2Attributes ofKakao(String provider, String attributeKey, Map<String, Object> attributes) {
+		final Map<String, Object> profile = (Map<String, Object>)attributes.get("profile");
+		final Map<String, Object> account = (Map<String, Object>)attributes.get("kakao_acount");
+
+		final String nickname = profile.containsKey("nickname") ? (String)profile.get("nickname") : "";
+		final String email = account.containsKey("email") ? (String)account.get("email") : "";
+		return OAuth2Attributes.builder()
+			.provider(provider)
+			.nickname(nickname)
+			.email(email)
+			.attributes(attributes)
+			.attributeKey(attributeKey)
+			.build();
+	}
+
+	private static OAuth2Attributes ofNaver(String provider, String attributeKey, Map<String, Object> attributes) {
+		final Map<String, Object> response = (Map<String, Object>)attributes.get("response");
+
+		final String nickname = response.containsKey("nickname") ? (String)response.get("nickname") : "";
+		final String email = response.containsKey("email") ? (String)response.get("email") : "";
+		return OAuth2Attributes.builder()
+			.provider(provider)
+			.nickname(nickname)
+			.email(email)
+			.attributes(response)
+			.attributeKey(attributeKey)
+			.build();
+	}
+
+	public Map<String, Object> convertToMap() {
+		final Map<String, Object> map = new HashMap<>();
+		map.put("provider", provider);
+		map.put("id", attributeKey);
+		map.put("key", attributeKey);
+		map.put("nickname", nickname);
+		map.put("email", email);
+
+		return map;
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/config/security/oauth2/OAuth2SuccessHandler.java
+++ b/module-domain/src/main/java/com/zoopi/config/security/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,68 @@
+package com.zoopi.config.security.oauth2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoopi.domain.authentication.dto.JwtDto;
+import com.zoopi.util.JwtUtils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+	private final JwtUtils jwtUtils;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+		final OAuth2User user = (OAuth2User)authentication.getPrincipal();
+		final JwtDto jwtDto = generateJwt(user);
+		setResponse(response, jwtDto);
+	}
+
+	private JwtDto generateJwt(OAuth2User oAuth2User) {
+		final String accessToken = jwtUtils.generateJwt(oAuth2User, JwtUtils.JwtType.ACCESS_TOKEN);
+		final String refreshToken = jwtUtils.generateJwt(oAuth2User, JwtUtils.JwtType.REFRESH_TOKEN);
+		return new JwtDto(accessToken, refreshToken);
+	}
+
+	private void setResponse(HttpServletResponse response, JwtDto jwtDto) {
+		final ObjectMapper objectMapper = new ObjectMapper();
+		try (OutputStream os = response.getOutputStream()) {
+			objectMapper.writeValue(os, new Response(200, "R-M006", "로그인에 성공하였습니다.", jwtDto));
+			os.flush();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		response.setStatus(HttpStatus.OK.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+	}
+
+	@Getter
+	@AllArgsConstructor
+	private static class Response {
+
+		private final int status;
+		private final String code;
+		private final String message;
+		private final Object data;
+
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/authentication/dto/JwtDto.java
+++ b/module-domain/src/main/java/com/zoopi/domain/authentication/dto/JwtDto.java
@@ -1,0 +1,13 @@
+package com.zoopi.domain.authentication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtDto {
+
+	private String accessToken;
+	private String refreshToken;
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/dto/SigninResponse.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/dto/SigninResponse.java
@@ -1,0 +1,24 @@
+package com.zoopi.domain.member.dto;
+
+import com.zoopi.domain.authentication.dto.JwtDto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SigninResponse {
+
+	private JwtDto jwt;
+	private SigninResult result;
+
+	public enum SigninResult {
+
+		SUCCESS, NONEXISTENT_USERNAME, MISMATCHED_PASSWORD
+
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/AuthorityType.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/AuthorityType.java
@@ -1,0 +1,7 @@
+package com.zoopi.domain.member.entity;
+
+public enum AuthorityType {
+
+	ROLE_USER, ROLE_ADMIN
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/Member.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/Member.java
@@ -35,8 +35,8 @@ public class Member {
 	@Column(name = "member_id")
 	private Long id;
 
-	@Column(name = "member_email", unique = true)
-	private String email;
+	@Column(name = "member_username", unique = true)
+	private String username;
 
 	@Column(name = "member_password")
 	private String password;
@@ -56,8 +56,8 @@ public class Member {
 	private JoinType joinType;
 
 	@Builder
-	public Member(String email, String password, String name, String phone, JoinType joinType) {
-		this.email = email;
+	public Member(String username, String password, String name, String phone, JoinType joinType) {
+		this.username = username;
 		this.password = password;
 		this.name = name;
 		this.phone = phone;

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/MemberAuthority.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/MemberAuthority.java
@@ -1,0 +1,47 @@
+package com.zoopi.domain.member.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "member_authorities", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"member_id", "member_authority_type"})
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberAuthority {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "member_authority_type")
+	private AuthorityType type;
+
+	@Builder
+	public MemberAuthority(Member member, AuthorityType type) {
+		this.member = member;
+		this.type = type;
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/KakaoAccount.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/KakaoAccount.java
@@ -1,0 +1,33 @@
+package com.zoopi.domain.member.entity.oauth2;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import com.zoopi.domain.member.entity.Member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "kakao_acounts")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoAccount {
+
+	@Id
+	@Column(name = "kakao_account_id")
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/NaverAccount.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/NaverAccount.java
@@ -1,0 +1,33 @@
+package com.zoopi.domain.member.entity.oauth2;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import com.zoopi.domain.member.entity.Member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "naver_acounts")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NaverAccount {
+
+	@Id
+	@Column(name = "naver_account_id")
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberAuthorityRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberAuthorityRepository.java
@@ -1,0 +1,14 @@
+package com.zoopi.domain.member.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.MemberAuthority;
+
+public interface MemberAuthorityRepository extends JpaRepository<MemberAuthority, Long> {
+
+	List<MemberAuthority> findAllByMember(Member member);
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/repository/MemberRepository.java
@@ -8,7 +8,7 @@ import com.zoopi.domain.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-	Optional<Member> findByEmail(String email);
+	Optional<Member> findByUsername(String username);
 
 	Optional<Member> findByPhone(String phone);
 

--- a/module-domain/src/main/java/com/zoopi/domain/member/repository/oauth2/KakaoAccountRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/repository/oauth2/KakaoAccountRepository.java
@@ -1,0 +1,9 @@
+package com.zoopi.domain.member.repository.oauth2;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zoopi.domain.member.entity.oauth2.KakaoAccount;
+
+public interface KakaoAccountRepository extends JpaRepository<KakaoAccount, Long> {
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/repository/oauth2/NaverAccountRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/repository/oauth2/NaverAccountRepository.java
@@ -1,0 +1,9 @@
+package com.zoopi.domain.member.repository.oauth2;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zoopi.domain.member.entity.oauth2.NaverAccount;
+
+public interface NaverAccountRepository extends JpaRepository<NaverAccount, Long> {
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/service/MemberAuthorityService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/service/MemberAuthorityService.java
@@ -1,0 +1,36 @@
+package com.zoopi.domain.member.service;
+
+import static com.zoopi.exception.response.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.MemberAuthority;
+import com.zoopi.domain.member.repository.MemberAuthorityRepository;
+import com.zoopi.domain.member.repository.MemberRepository;
+import com.zoopi.exception.EntityNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberAuthorityService {
+
+	private final MemberRepository memberRepository;
+	private final MemberAuthorityRepository memberAuthorityRepository;
+
+	public List<MemberAuthority> getMemberAuthorities(String email) {
+		final Member member = memberRepository.findByUsername(email)
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
+		return memberAuthorityRepository.findAllByMember(member);
+	}
+
+	public List<MemberAuthority> getMemberAuthorities(Member member) {
+		return memberAuthorityRepository.findAllByMember(member);
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/member/service/MemberAuthorityService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/service/MemberAuthorityService.java
@@ -2,6 +2,7 @@ package com.zoopi.domain.member.service;
 
 import static com.zoopi.exception.response.ErrorCode.*;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -26,11 +27,13 @@ public class MemberAuthorityService {
 	public List<MemberAuthority> getMemberAuthorities(String email) {
 		final Member member = memberRepository.findByUsername(email)
 			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
-		return memberAuthorityRepository.findAllByMember(member);
+		final List<MemberAuthority> memberAuthorities = memberAuthorityRepository.findAllByMember(member);
+		return List.copyOf(memberAuthorities);
 	}
 
 	public List<MemberAuthority> getMemberAuthorities(Member member) {
-		return memberAuthorityRepository.findAllByMember(member);
+		final List<MemberAuthority> memberAuthorities = memberAuthorityRepository.findAllByMember(member);
+		return List.copyOf(memberAuthorities);
 	}
 
 }

--- a/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
@@ -50,13 +50,17 @@ public class MemberService {
 			.build();
 		memberRepository.save(member);
 
+		saveMemberAuthority(member);
+
+		return member;
+	}
+
+	private void saveMemberAuthority(Member member) {
 		final MemberAuthority memberAuthority = MemberAuthority.builder()
 			.member(member)
 			.type(AuthorityType.ROLE_USER)
 			.build();
 		memberAuthorityRepository.save(memberAuthority);
-
-		return member;
 	}
 
 	public SigninResponse signin(String email, String password) {
@@ -72,11 +76,16 @@ public class MemberService {
 		}
 
 		final List<MemberAuthority> authorities = memberAuthorityRepository.findAllByMember(member);
+		final JwtDto jwt = generateJwt(member, authorities);
+
+		return new SigninResponse(jwt, SUCCESS);
+	}
+
+	private JwtDto generateJwt(Member member, List<MemberAuthority> authorities) {
 		final String accessToken = jwtUtils.generateJwt(member, authorities, JwtUtils.JwtType.ACCESS_TOKEN);
 		final String refreshToken = jwtUtils.generateJwt(member, authorities, JwtUtils.JwtType.REFRESH_TOKEN);
 
-		final JwtDto jwt = new JwtDto(accessToken, refreshToken);
-		return new SigninResponse(jwt, SUCCESS);
+		return new JwtDto(accessToken, refreshToken);
 	}
 
 }

--- a/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/service/MemberService.java
@@ -1,12 +1,25 @@
 package com.zoopi.domain.member.service;
 
+import static com.zoopi.exception.response.ErrorCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.zoopi.domain.authentication.dto.JwtDto;
 import com.zoopi.domain.member.entity.JoinType;
 import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.AuthorityType;
+import com.zoopi.domain.member.entity.MemberAuthority;
 import com.zoopi.domain.member.repository.MemberRepository;
+import com.zoopi.domain.member.repository.MemberAuthorityRepository;
+import com.zoopi.exception.EntityNotFoundException;
+import com.zoopi.exception.InvalidArgumentException;
+import com.zoopi.exception.response.ErrorResponse;
+import com.zoopi.util.JwtUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,9 +30,11 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final MemberAuthorityRepository memberAuthorityRepository;
+	private final JwtUtils jwtUtils;
 
 	public boolean validateEmail(String email) {
-		return memberRepository.findByEmail(email).isEmpty();
+		return memberRepository.findByUsername(email).isEmpty();
 	}
 
 	public boolean validatePhone(String phone) {
@@ -27,8 +42,41 @@ public class MemberService {
 	}
 
 	@Transactional
-	public Member createMember(String email, String phone, String name, String password) {
-		return memberRepository.save(new Member(email, passwordEncoder.encode(password), name, phone, JoinType.EMAIL));
+	public Member createMember(String email, String phone, String name, String password, JoinType joinType) {
+		final Member member = Member.builder()
+			.username(email)
+			.password(passwordEncoder.encode(password))
+			.name(name)
+			.phone(phone)
+			.joinType(joinType)
+			.build();
+		memberRepository.save(member);
+
+		final MemberAuthority memberAuthority = MemberAuthority.builder()
+			.member(member)
+			.type(AuthorityType.ROLE_USER)
+			.build();
+		memberAuthorityRepository.save(memberAuthority);
+
+		return member;
+	}
+
+	public JwtDto signin(String email, String password) {
+		final Member member = memberRepository.findByUsername(email)
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
+
+		final boolean isMatchedPassword = passwordEncoder.matches(password, member.getPassword());
+		if (!isMatchedPassword) {
+			final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of("password", password,
+				MEMBER_PASSWORD_MISMATCHED);
+			throw new InvalidArgumentException(errors);
+		}
+
+		final List<MemberAuthority> authorities = memberAuthorityRepository.findAllByMember(member);
+		final String accessToken = jwtUtils.generateJwt(member, authorities, JwtUtils.JwtType.ACCESS_TOKEN);
+		final String refreshToken = jwtUtils.generateJwt(member, authorities, JwtUtils.JwtType.REFRESH_TOKEN);
+
+		return new JwtDto(accessToken, refreshToken);
 	}
 
 }

--- a/module-domain/src/main/java/com/zoopi/exception/AuthenticationException.java
+++ b/module-domain/src/main/java/com/zoopi/exception/AuthenticationException.java
@@ -1,0 +1,14 @@
+package com.zoopi.exception;
+
+import java.util.List;
+
+import com.zoopi.exception.response.ErrorCode;
+import com.zoopi.exception.response.ErrorResponse;
+
+public class AuthenticationException extends BusinessException {
+
+	public AuthenticationException(List<ErrorResponse.FieldError> errors) {
+		super(ErrorCode.AUTHENTICATION_FAILURE, errors);
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/exception/InvalidRequestHeaderException.java
+++ b/module-domain/src/main/java/com/zoopi/exception/InvalidRequestHeaderException.java
@@ -1,0 +1,14 @@
+package com.zoopi.exception;
+
+import java.util.List;
+
+import com.zoopi.exception.response.ErrorCode;
+import com.zoopi.exception.response.ErrorResponse;
+
+public class InvalidRequestHeaderException extends BusinessException {
+
+	public InvalidRequestHeaderException(List<ErrorResponse.FieldError> errors) {
+		super(ErrorCode.REQUEST_HEADER_MISSING, errors);
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/exception/response/ErrorCode.java
+++ b/module-domain/src/main/java/com/zoopi/exception/response/ErrorCode.java
@@ -8,16 +8,29 @@ import lombok.Getter;
 public enum ErrorCode {
 
 	// Global
-	INTERNAL_SERVER_ERROR(500, "G001", "내부 서버 오류입니다."),
-	INPUT_VALUE_INVALID(400, "G002", "입력 값이 유효하지 않습니다."),
-	INPUT_TYPE_INVALID(400, "G003", "입력 타입이 유효하지 않습니다."),
-	METHOD_NOT_ALLOWED(405, "G004", "허용되지 않은 HTTP method 입니다."),
-	HTTP_MESSAGE_NOT_READABLE(400, "G005", "HTTP Request Body 형식이 올바르지 않습니다."),
-	REQUEST_PARAMETER_MISSING(400, "G006", "요청 파라미터는 필수입니다."),
+	INTERNAL_SERVER_ERROR(500, "E-G001", "내부 서버 오류입니다."),
+	INPUT_VALUE_INVALID(400, "E-G002", "입력 값이 유효하지 않습니다."),
+	INPUT_TYPE_INVALID(400, "E-G003", "입력 타입이 유효하지 않습니다."),
+	METHOD_NOT_ALLOWED(405, "E-G004", "허용되지 않은 HTTP method 입니다."),
+	HTTP_MESSAGE_NOT_READABLE(400, "E-G005", "HTTP Request Body 형식이 올바르지 않습니다."),
+	REQUEST_PARAMETER_MISSING(400, "E-G006", "요청 파라미터는 필수입니다."),
+	REQUEST_HEADER_MISSING(400, "E-G007", "요청 헤더는 필수입니다."),
+
+	// Authorization
+	AUTHORIZATION_HEADER_MISSING(400, "E-A001", "인증 헤더는 필수입니다."),
+	INVALID_BEARER_PREFIX(400, "E-A002", "인증 헤더에 Bearer 접두사는 필수입니다."),
+	AUTHENTICATION_FAILURE(401, "E-A003", "인증에 실패하였습니다."),
+	INSUFFICIENT_AUTHORITY(403, "E-A004", "접근 권한이 부족합니다."),
+	PASSWORD_MISMATCHED(403, "E-A005", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+
+	// Member
+	MEMBER_NOT_FOUND(400, "E-M001", "존재하지 않는 회원입니다"),
+	MEMBER_PASSWORD_MISMATCHED(400, "E-M002", "회원 비밀번호가 올바르지 않습니다."),
 
 	;
 
 	private final int status;
 	private final String code;
 	private final String message;
+
 }

--- a/module-domain/src/main/java/com/zoopi/exception/response/ErrorCode.java
+++ b/module-domain/src/main/java/com/zoopi/exception/response/ErrorCode.java
@@ -25,7 +25,6 @@ public enum ErrorCode {
 
 	// Member
 	MEMBER_NOT_FOUND(400, "E-M001", "존재하지 않는 회원입니다"),
-	MEMBER_PASSWORD_MISMATCHED(400, "E-M002", "회원 비밀번호가 올바르지 않습니다."),
 
 	;
 

--- a/module-domain/src/main/java/com/zoopi/exception/response/ErrorResponse.java
+++ b/module-domain/src/main/java/com/zoopi/exception/response/ErrorResponse.java
@@ -97,6 +97,12 @@ public class ErrorResponse {
 			return fieldErrors;
 		}
 
+		public static List<FieldError> of(final String field, final String value, final ErrorCode errorCode) {
+			final List<FieldError> fieldErrors = new ArrayList<>();
+			fieldErrors.add(new FieldError(field, value, errorCode.getMessage()));
+			return fieldErrors;
+		}
+
 		private static List<FieldError> of(final BindingResult bindingResult) {
 			final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
 			return fieldErrors.stream()

--- a/module-domain/src/main/java/com/zoopi/filter/JwtRequestFilter.java
+++ b/module-domain/src/main/java/com/zoopi/filter/JwtRequestFilter.java
@@ -1,0 +1,76 @@
+package com.zoopi.filter;
+
+import static com.zoopi.exception.response.ErrorCode.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.zoopi.exception.AuthenticationException;
+import com.zoopi.exception.InvalidRequestHeaderException;
+import com.zoopi.exception.response.ErrorResponse;
+import com.zoopi.util.JwtUtils;
+
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String BEARER_PREFIX = "Bearer "; // RFC 6750: JWT, OAuth 2.0 token are bearer tokens
+	public static final int BEARER_PREFIX_LENGTH = 7;
+
+	private final JwtUtils jwtUtils;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			final String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+			final List<ErrorResponse.FieldError> errors = validateAuthorizationHeader(authorizationHeader);
+			if (errors.isEmpty()) {
+				final String jwt = authorizationHeader.substring(BEARER_PREFIX_LENGTH);
+				final String username = jwtUtils.getUsername(jwt);
+
+				if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+					final Authentication authenticationToken = jwtUtils.getAuthentication(jwt);
+					SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+				}
+			} else {
+				request.setAttribute("exception", new AuthenticationException(errors));
+			}
+		} catch (InvalidRequestHeaderException | JwtException e) {
+			request.setAttribute("exception", e);
+		} catch (Exception e) {
+			e.printStackTrace();
+			request.setAttribute("exception", e);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private List<ErrorResponse.FieldError> validateAuthorizationHeader(String authorizationHeader) {
+		final List<ErrorResponse.FieldError> errors = new ArrayList<>();
+		if (authorizationHeader == null) {
+			errors.add(new ErrorResponse.FieldError("Authorization", "",
+				AUTHORIZATION_HEADER_MISSING.getMessage()));
+		} else if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+			errors.add(new ErrorResponse.FieldError("Authorization", authorizationHeader,
+				INVALID_BEARER_PREFIX.getMessage()));
+		}
+		return errors;
+	}
+
+}

--- a/module-domain/src/main/java/com/zoopi/util/JwtUtils.java
+++ b/module-domain/src/main/java/com/zoopi/util/JwtUtils.java
@@ -1,0 +1,133 @@
+package com.zoopi.util;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.MemberAuthority;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+@Component
+public class JwtUtils {
+
+	private static final String AUTHORITIES_KEY = "authorities";
+	private static final String JWT_TYPE = "jwt_type";
+	private static final String TYPE = "typ";
+	private static final String JWT = "JWT";
+
+	@Value("${jwt.access-validity}")
+	private long ACCESS_TOKEN_VALIDITY;
+	@Value("${jwt.refresh-validity}")
+	private long REFRESH_TOKEN_VALIDITY;
+	@Value("${jwt.secret}")
+	private String SECRET_KEY;
+
+	@PostConstruct
+	protected void init() {
+		SECRET_KEY = Base64.getEncoder().encodeToString(SECRET_KEY.getBytes());
+	}
+
+	public Authentication getAuthentication(String token) {
+		final Claims claims = getAllClaims(token);
+		final List<SimpleGrantedAuthority> authorities = Arrays.stream(
+				claims.get(AUTHORITIES_KEY).toString().split(","))
+			.map(SimpleGrantedAuthority::new)
+			.collect(Collectors.toList());
+		final User principal = new User(claims.getSubject(), "", authorities);
+
+		return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+	}
+
+	public String generateJwt(OAuth2User oAuth2User, JwtType type) {
+		final Map<String, Object> claims = new HashMap<>();
+		final String authorities = oAuth2User.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+		claims.put(AUTHORITIES_KEY, authorities);
+		claims.put(JWT_TYPE, type);
+
+		final Map<String, Object> headers = new HashMap<>();
+		headers.put(TYPE, JWT);
+
+		final Date now = new Date(System.currentTimeMillis());
+		final Date validity = new Date(System.currentTimeMillis() +
+			(type.equals(JwtType.ACCESS_TOKEN) ? ACCESS_TOKEN_VALIDITY : REFRESH_TOKEN_VALIDITY));
+		final String email = (String)oAuth2User.getAttributes().get("email");
+
+		return Jwts.builder()
+			.setHeader(headers)
+			.setClaims(claims)
+			.setSubject(email)
+			.setIssuedAt(now)
+			.setExpiration(validity)
+			.signWith(SignatureAlgorithm.HS512, SECRET_KEY)
+			.compact();
+	}
+
+	public String generateJwt(Member member, List<MemberAuthority> memberAuthorities, JwtType type) {
+		final Map<String, Object> claims = new HashMap<>();
+		final String authorities = memberAuthorities.stream()
+			.map(MemberAuthority::getType)
+			.map(Enum::name)
+			.collect(Collectors.joining(","));
+		claims.put(AUTHORITIES_KEY, authorities);
+		claims.put(JWT_TYPE, type);
+
+		final Map<String, Object> headers = new HashMap<>();
+		headers.put(TYPE, JWT);
+
+		final Date now = new Date(System.currentTimeMillis());
+		final Date validity = new Date(System.currentTimeMillis() +
+			(type.equals(JwtType.ACCESS_TOKEN) ? ACCESS_TOKEN_VALIDITY : REFRESH_TOKEN_VALIDITY));
+		final String email = member.getUsername();
+
+		return Jwts.builder()
+			.setHeader(headers)
+			.setClaims(claims)
+			.setSubject(email)
+			.setIssuedAt(now)
+			.setExpiration(validity)
+			.signWith(SignatureAlgorithm.HS512, SECRET_KEY)
+			.compact();
+	}
+
+	public String getUsername(String token) {
+		return getClaim(token, Claims::getSubject);
+	}
+
+	public <T> T getClaim(String token, Function<Claims, T> claimsResolver) {
+		final Claims claims = getAllClaims(token);
+		return claimsResolver.apply(claims);
+	}
+
+	private Claims getAllClaims(String token) {
+		return Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody();
+	}
+
+	public enum JwtType {
+
+		ACCESS_TOKEN, REFRESH_TOKEN
+
+	}
+
+}

--- a/module-domain/src/test/java/com/zoopi/domain/member/service/MemberAuthorityServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/member/service/MemberAuthorityServiceTest.java
@@ -1,0 +1,84 @@
+package com.zoopi.domain.member.service;
+
+import static com.zoopi.domain.member.util.MemberUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.zoopi.domain.member.entity.AuthorityType;
+import com.zoopi.domain.member.entity.JoinType;
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.MemberAuthority;
+import com.zoopi.domain.member.repository.MemberAuthorityRepository;
+import com.zoopi.domain.member.repository.MemberRepository;
+import com.zoopi.exception.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class MemberAuthorityServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private MemberAuthorityRepository memberAuthorityRepository;
+
+	@InjectMocks
+	private MemberAuthorityService memberAuthorityService;
+
+	@Test
+	void getMemberAuthorities_ValidEmail_Success() throws Exception {
+		// given
+		final Member member = getMember(JoinType.EMAIL);
+		final List<MemberAuthority> authorities = getAuthorities(member, AuthorityType.ROLE_USER);
+
+		doReturn(Optional.of(member)).when(memberRepository).findByUsername(member.getUsername());
+		doReturn(authorities).when(memberAuthorityRepository).findAllByMember(member);
+
+		// when
+		final List<MemberAuthority> memberAuthorities = memberAuthorityService.getMemberAuthorities(
+			member.getUsername());
+
+		// then
+		assertThat(memberAuthorities).isEqualTo(authorities);
+	}
+
+	@Test
+	void getMemberAuthorities_InvalidEmail_ThrownException() throws Exception {
+		// given
+		final String username = "zoopi@gmail.com";
+
+		doReturn(Optional.empty()).when(memberRepository).findByUsername(username);
+
+		// when
+		final Executable executable = () -> memberAuthorityService.getMemberAuthorities(username);
+
+		// then
+		assertThrows(EntityNotFoundException.class, executable);
+	}
+
+	@Test
+	void getMemberAuthorities_ValidMember_Success() throws Exception {
+		// given
+		final Member member = getMember(JoinType.EMAIL);
+		final List<MemberAuthority> authorities = getAuthorities(member, AuthorityType.ROLE_USER);
+
+		doReturn(authorities).when(memberAuthorityRepository).findAllByMember(member);
+
+		// when
+		final List<MemberAuthority> memberAuthorities = memberAuthorityService.getMemberAuthorities(member);
+
+		// then
+		assertThat(memberAuthorities).isEqualTo(authorities);
+	}
+
+}

--- a/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.zoopi.domain.member.service;
 
+import static com.zoopi.domain.member.util.MemberUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -168,27 +169,6 @@ class MemberServiceTest {
 		assertThat(response.getResult()).isEqualTo(SigninResponse.SigninResult.NONEXISTENT_USERNAME);
 		assertThat(response.getJwt().getAccessToken()).isEqualTo("");
 		assertThat(response.getJwt().getRefreshToken()).isEqualTo("");
-	}
-
-	public Member getMember(JoinType type) {
-		return Member.builder()
-			.joinType(type)
-			.phone("01012341234")
-			.name("홍길동")
-			.password("qlalfqjsgh1!")
-			.username("zoopi@gmail.com")
-			.build();
-	}
-
-	public List<MemberAuthority> getAuthorities(Member member, AuthorityType type) {
-		if (type.equals(AuthorityType.ROLE_USER)) {
-			return List.of(new MemberAuthority(member, AuthorityType.ROLE_USER));
-		} else if (type.equals(AuthorityType.ROLE_ADMIN)) {
-			return List.of(new MemberAuthority(member, AuthorityType.ROLE_USER),
-				new MemberAuthority(member, AuthorityType.ROLE_ADMIN));
-		} else {
-			return null;
-		}
 	}
 
 }

--- a/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
+++ b/module-domain/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -13,15 +14,26 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.zoopi.domain.member.dto.SigninResponse;
+import com.zoopi.domain.member.entity.AuthorityType;
 import com.zoopi.domain.member.entity.JoinType;
 import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.MemberAuthority;
+import com.zoopi.domain.member.repository.MemberAuthorityRepository;
 import com.zoopi.domain.member.repository.MemberRepository;
+import com.zoopi.util.JwtUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
 	@Mock
 	private MemberRepository memberRepository;
+
+	@Mock
+	private MemberAuthorityRepository memberAuthorityRepository;
+
+	@Mock
+	private JwtUtils jwtUtils;
 
 	@Mock
 	private PasswordEncoder passwordEncoder;
@@ -31,12 +43,13 @@ class MemberServiceTest {
 
 	@Test
 	void validateEmail_UniqueEmail_True() throws Exception {
-	    // given
-		final String email = "unique@zoopi.com";
-		doReturn(Optional.empty()).when(memberRepository).findByEmail(email);
+		// given
+		final String username = getMember(JoinType.EMAIL).getUsername();
 
-	    // when
-		final boolean isValidated = memberService.validateEmail(email);
+		doReturn(Optional.empty()).when(memberRepository).findByUsername(username);
+
+		// when
+		final boolean isValidated = memberService.validateEmail(username);
 
 		// then
 		assertThat(isValidated).isTrue();
@@ -44,12 +57,13 @@ class MemberServiceTest {
 
 	@Test
 	void validateEmail_DuplicateEmail_False() throws Exception {
-	    // given
-		final String email = "duplicate@zoopi.com";
-		doReturn(Optional.of(mock(Member.class))).when(memberRepository).findByEmail(email);
+		// given
+		final String username = getMember(JoinType.EMAIL).getUsername();
 
-	    // when
-		final boolean isValidated = memberService.validateEmail(email);
+		doReturn(Optional.of(mock(Member.class))).when(memberRepository).findByUsername(username);
+
+		// when
+		final boolean isValidated = memberService.validateEmail(username);
 
 		// then
 		assertThat(isValidated).isFalse();
@@ -57,11 +71,12 @@ class MemberServiceTest {
 
 	@Test
 	void validatePhone_UniquePhone_True() throws Exception {
-	    // given
-		final String phone = "01012345678";
+		// given
+		final String phone = getMember(JoinType.EMAIL).getPhone();
+
 		doReturn(Optional.empty()).when(memberRepository).findByPhone(phone);
 
-	    // when
+		// when
 		final boolean isValidated = memberService.validatePhone(phone);
 
 		// then
@@ -70,11 +85,12 @@ class MemberServiceTest {
 
 	@Test
 	void validatePhone_DuplicatePhone_False() throws Exception {
-	    // given
-		final String phone = "01012345678";
+		// given
+		final String phone = getMember(JoinType.EMAIL).getPhone();
+
 		doReturn(Optional.of(mock(Member.class))).when(memberRepository).findByPhone(phone);
 
-	    // when
+		// when
 		final boolean isValidated = memberService.validatePhone(phone);
 
 		// then
@@ -82,20 +98,97 @@ class MemberServiceTest {
 	}
 
 	@Test
-	void createMember_EmailAndPhoneAndNameAndPassword_SuccessToSave() throws Exception {
-	    // given
-		final String email = "zoopi@gmail.com";
-		final String phone = "01012341234";
-		final String name = "주피";
-		final String password = "qlalfqjsgh1!";
-		final Member member = new Member(email, password, name, phone, JoinType.EMAIL);
+	void createMember_ValidArguments_SuccessToSave() throws Exception {
+		// given
+		final Member member = getMember(JoinType.EMAIL);
+
 		doReturn(member).when(memberRepository).save(any(Member.class));
 
-	    // when
-		final Member savedMember = memberService.createMember(email, phone, name, password);
+		// when
+		final Member savedMember = memberService.createMember(member.getUsername(), member.getPhone(), member.getName(),
+			member.getPassword(), JoinType.EMAIL);
 
 		// then
-		assertThat(member).isEqualTo(savedMember);
+		assertThat(member.getPhone()).isEqualTo(savedMember.getPhone());
+	}
+
+	@Test
+	void signin_ValidEmailAndMatchedPassword_Success() throws Exception {
+		// given
+		final Member member = getMember(JoinType.EMAIL);
+		final List<MemberAuthority> authorities = getAuthorities(member, AuthorityType.ROLE_USER);
+		final String accessToken = "accessToken";
+		final String refreshToken = "refreshToken";
+
+		doReturn(Optional.of(member)).when(memberRepository).findByUsername(any(String.class));
+		doReturn(true).when(passwordEncoder).matches(any(String.class), any(String.class));
+		doReturn(authorities).when(memberAuthorityRepository).findAllByMember(any(Member.class));
+		doReturn(accessToken).when(jwtUtils).generateJwt(member, authorities, JwtUtils.JwtType.ACCESS_TOKEN);
+		doReturn(refreshToken).when(jwtUtils).generateJwt(member, authorities, JwtUtils.JwtType.REFRESH_TOKEN);
+
+		// when
+		final SigninResponse response = memberService.signin(member.getUsername(), member.getPassword());
+
+		// then
+		assertThat(response.getResult()).isEqualTo(SigninResponse.SigninResult.SUCCESS);
+		assertThat(response.getJwt().getAccessToken()).isEqualTo(accessToken);
+		assertThat(response.getJwt().getRefreshToken()).isEqualTo(refreshToken);
+	}
+
+	@Test
+	void signin_MismatchedPassword_Fail() throws Exception {
+		// given
+		final Member member = getMember(JoinType.EMAIL);
+		final String wrongPassword = "qlalfqjsgh2@";
+
+		doReturn(Optional.of(member)).when(memberRepository).findByUsername(any(String.class));
+		doReturn(false).when(passwordEncoder).matches(wrongPassword, member.getPassword());
+
+		// when
+		final SigninResponse response = memberService.signin(member.getUsername(), wrongPassword);
+
+		// then
+		assertThat(response.getResult()).isEqualTo(SigninResponse.SigninResult.MISMATCHED_PASSWORD);
+		assertThat(response.getJwt().getAccessToken()).isEqualTo("");
+		assertThat(response.getJwt().getRefreshToken()).isEqualTo("");
+	}
+
+	@Test
+	void signin_InvalidEmail_Fail() throws Exception {
+		// given
+		final String wrongUsername = "nop@gmail.com";
+		final String wrongPassword = "qlalfqjsgh2@";
+
+		doReturn(Optional.empty()).when(memberRepository).findByUsername(any(String.class));
+
+		// when
+		final SigninResponse response = memberService.signin(wrongUsername, wrongPassword);
+
+		// then
+		assertThat(response.getResult()).isEqualTo(SigninResponse.SigninResult.NONEXISTENT_USERNAME);
+		assertThat(response.getJwt().getAccessToken()).isEqualTo("");
+		assertThat(response.getJwt().getRefreshToken()).isEqualTo("");
+	}
+
+	public Member getMember(JoinType type) {
+		return Member.builder()
+			.joinType(type)
+			.phone("01012341234")
+			.name("홍길동")
+			.password("qlalfqjsgh1!")
+			.username("zoopi@gmail.com")
+			.build();
+	}
+
+	public List<MemberAuthority> getAuthorities(Member member, AuthorityType type) {
+		if (type.equals(AuthorityType.ROLE_USER)) {
+			return List.of(new MemberAuthority(member, AuthorityType.ROLE_USER));
+		} else if (type.equals(AuthorityType.ROLE_ADMIN)) {
+			return List.of(new MemberAuthority(member, AuthorityType.ROLE_USER),
+				new MemberAuthority(member, AuthorityType.ROLE_ADMIN));
+		} else {
+			return null;
+		}
 	}
 
 }

--- a/module-domain/src/test/java/com/zoopi/domain/member/util/MemberUtils.java
+++ b/module-domain/src/test/java/com/zoopi/domain/member/util/MemberUtils.java
@@ -1,0 +1,33 @@
+package com.zoopi.domain.member.util;
+
+import java.util.List;
+
+import com.zoopi.domain.member.entity.AuthorityType;
+import com.zoopi.domain.member.entity.JoinType;
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.MemberAuthority;
+
+public class MemberUtils {
+
+	public static Member getMember(JoinType type) {
+		return Member.builder()
+			.joinType(type)
+			.phone("01012341234")
+			.name("홍길동")
+			.password("qlalfqjsgh1!")
+			.username("zoopi@gmail.com")
+			.build();
+	}
+
+	public static List<MemberAuthority> getAuthorities(Member member, AuthorityType type) {
+		if (type.equals(AuthorityType.ROLE_USER)) {
+			return List.of(new MemberAuthority(member, AuthorityType.ROLE_USER));
+		} else if (type.equals(AuthorityType.ROLE_ADMIN)) {
+			return List.of(new MemberAuthority(member, AuthorityType.ROLE_USER),
+				new MemberAuthority(member, AuthorityType.ROLE_ADMIN));
+		} else {
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌 Linked Issues
- Resolve: #11 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## 🔎 Change Details
### 1. OAuth2(kakao, naver) 로그인 로직 추가
- 첫 번째 로그인인 경우, 회원 가입 로직 포함(`CustomOAuth2UserService`)
- 로그인에 성공한 경우 ResponseBody에 JWT(AccessToken, RefreshToken)을 넣어서 전달(`OAuth2SuccessHandler`)
    - 개발 서버 배포 후에는 RefreshToken은 Cookie(HttpOnly)에 저장하도록 수정 필요

### 2. 인증/인가 실패 핸들러 추가 및 시큐리티 설정 클래스 추가
- `CustomAccessDeniedHandler`: 404 응답
- `CustomAuthenticationEntryPoint`: RequestHeader가 올바르지 않거나, JWT 관련 예외인 경우 401 응답
    > JWT 관련 예외가 여러 개 있는데, 몇 개는 정확하게 어떤 상황에서 발생하는지 모르겠어서 따로 ErrorCode는 추가하지 않았고, 각 예외 기본 메시지를 그대로 사용했습니다.
    > 이 부분은 천천히 좀 더 찾아보면서 업데이트하도록 하겠습니다.

### 3. Member 엔티티 필드명 변경
- email -> username: 추후에 username과 email을 분리할 가능성을 염두하여 수정하였습니다.
    - 회원 가입 시에만 `@Email`으로 유효성 검증을 진행하고, DB에는 username으로 저장하는 것이 로그인에 사용되는 아이디라는 것을 파악하기 쉬울 것 같다는 생각도 들었습니다.

### 4. 회원 가입 시 비밀번호 검증 정규식 수정
- 사용 가능한 특수 문자: `, ~, *, (, ) 추가
    - 안정성을 조금 더 높이기 위해 사용 가능한 특수 문자를 몇 개 더 추가하였습니다.

### 5. 이메일 로그인 기능 추가
- 로그인 요청 시 다음의 3가지 결과가 존재합니다.
    1. 해당 아이디가 존재하지 않는 경우 -> 200 응답
    2. 비밀번호가 일치하지 않는 경우 -> 200 응답
    3. 로그인에 성공한 경우 -> 200 응답
- 클라이언트가 API 스펙을 어긴 것이 아니기 때문에, 1번과 2번의 경우 200 응답으로 수정하였습니다.

### 6. 리스트 반환 시 불변 객체로 반환
- 회원의 권한을 조회할 때 리스트로 반환받는데, 이 리스트는 변경될 일이 없으므로 불변 객체로 감싸서 반환하도록 수정하였습니다.
    - 이렇게 사용하면 가비지 컬렉션의 성능 측면에서도 이점이 있다고 합니다.😲 ([Reference1](https://openjdk.java.net/jeps/269))
    > `Collections.unmodifiableList()` vs `List.copyOf()` vs `Arrays.asList()` vs `new ArrayList<>()`
    > `Collections.unmodifiableList()`: 수정 불가능한 리스트를 복사하지만, 원본과의 참조가 유지되어 원본이 수정되는 경우, 복사된 리스트의 값도 변경된다.
    > `List.copyOf()` : 원본과의 참조를 끊는 불변 리스트를 복사한다. 복사 대상이 불변 리스트인 경우 참조는 유지된다. (`JDK 9`)
    > `Arrays.asList()`: 원소의 수정은 가능하지만, 추가 및 제거는 불가능하다.
    > `new ArrayList<>()`: 원본과의 참조를 끊는 복사를 한다. 복사된 객체는 가변이다.

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬 Comment
- 시큐리티 관련 테스트는 천천히 작성해 보도록 하겠습니다!
- 회의 때 말씀드렸던 email 관련 질문입니다😇
    - 현재 JWT subject에 username(email)을 넣고 있는데, 카카오의 경우 이메일 수신 동의를 안하면 빈 값을 받게 됨 -> DB에서도 unique 속성을 만족 못함
        - 대안 1. username을 이메일 형식으로 사용x (필요 시 Member 테이블에 email 속성 추가)
        - 대안 2. JWT subject에 id(pk)를 넣어서 전달 + username(email) -> unique 속성 제거

<!--
✅ 참고한 문서가 있다면 공유해 주세요.
-->
## 📑 References
- (1) https://openjdk.java.net/jeps/269

## ✅ Check Lists
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
- [x] merge할 base branch가 올바른지 확인하셨나요?
