### PR TITLE
헌혈매칭(글) 엔티티 및 도메인 로직, API 구현

### DIFF
--- a/module-api/src/main/java/com/zoopi/controller/ResultCode.java
+++ b/module-api/src/main/java/com/zoopi/controller/ResultCode.java
@@ -28,6 +28,15 @@ public enum ResultCode {
 
 	// Ban
 	PHONE_BANNED(200, "R-B001", "인증번호 전송이 제한된 휴대폰 번호입니다. 24시간 후 재시도해 주세요."),
+
+	// BloodPost
+	BLOODPOST_REGISTER_SUCCESS(200, "R-BP001", "헌혈 요청글 등록에 성공하였습니다."),
+	BLOODPOST_UPDATE_SUCCESS(200, "R-BP002", "헌혈 요청글 수정에 성공하였습니다."),
+	BLOODPOST_SELECTALL_SUCCESS(200, "R-BP003", "헌혈 요청글 리스트 조회에 성공하였습니다."),
+	BLOODPOST_SELECT_SUCCESS(200, "R-BP004", "헌혈 요청글 상세조회에 성공하였습니다."),
+	BLOODPOST_DELETE_SUCCESS(200, "R-BP005", "헌혈 요청글 삭제에 성공하였습니다."),
+	BLOODPOST_EXPIRE_SUCCESS(200, "R-BP005", "헌혈 요청글 만료에 성공하였습니다."),
+	BLOODPOST_PULL_SUCCESS(200, "R-BP006", "헌혈 요청글 끌어올리기에 성공하였습니다."),
 	;
 
 	private final int status;

--- a/module-api/src/main/java/com/zoopi/controller/bloodpost/BloodPostController.java
+++ b/module-api/src/main/java/com/zoopi/controller/bloodpost/BloodPostController.java
@@ -1,0 +1,97 @@
+package com.zoopi.controller.bloodpost;
+
+import com.zoopi.controller.ResultCode;
+import com.zoopi.controller.ResultResponse;
+import com.zoopi.domain.bloodpost.dto.BloodPostDto;
+import com.zoopi.domain.bloodpost.entity.BloodPost;
+import com.zoopi.domain.bloodpost.service.BloodPostService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Api(tags = "헌혈 요청글 API")
+@RestController
+@RequestMapping("/blood-post")
+@RequiredArgsConstructor
+public class BloodPostController {
+
+    private final BloodPostService bloodPostService;
+
+    @ApiOperation("헌혈 요청글 리스트 조회")
+    @GetMapping
+    public ResponseEntity<ResultResponse> selectAllBloodPost(
+            @RequestParam(value = "status", required = false) BloodPost.Status status,
+            @RequestParam(value = "title", required = false) String title
+    ) {
+        List<BloodPostDto.InfoResponse> response = bloodPostService.selectAllBloodPost(status, title);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.BLOODPOST_SELECTALL_SUCCESS, response));
+    }
+
+    @ApiOperation("헌혈 요청글 상세조회")
+    @GetMapping("/{bloodPostId}")
+    public ResponseEntity<ResultResponse> selectBloodPost(
+            @PathVariable Long bloodPostId
+    ) {
+        BloodPostDto.InfoResponse response = bloodPostService.selectBloodPost(bloodPostId);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.BLOODPOST_SELECT_SUCCESS, response));
+    }
+
+    @ApiOperation("헌혈 요청글 등록")
+    @PostMapping
+    public ResponseEntity<ResultResponse> registerBloodPost(
+            @RequestBody @Valid BloodPostDto.RegisterRequest request
+    ) {
+        BloodPostDto.RegisterResponse response = bloodPostService.registerBloodPost(request.toEntity());
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.BLOODPOST_REGISTER_SUCCESS, response));
+    }
+
+    @ApiOperation("헌혈 요청글 수정")
+    @PatchMapping("/{bloodPostId}")
+    public ResponseEntity<ResultResponse> updateBloodPost(
+            @PathVariable Long bloodPostId,
+            @RequestBody @Valid BloodPostDto.UpdateRequest request
+    ) {
+        BloodPostDto.UpdateResponse response = bloodPostService.updateBloodPost(bloodPostId, request);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.BLOODPOST_UPDATE_SUCCESS, response));
+    }
+
+    @ApiOperation("헌혈 요청글 삭제")
+    @DeleteMapping("/{bloodPostId}")
+    public ResponseEntity<ResultResponse> deleteBloodPost(
+            @PathVariable Long bloodPostId
+    ) {
+        bloodPostService.deleteBloodPost(bloodPostId);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.BLOODPOST_DELETE_SUCCESS));
+    }
+
+    @ApiOperation("헌혈 요청글 만료")
+    @PatchMapping("/expire/{bloodPostId}")
+    public ResponseEntity<ResultResponse> expireBloodPost(
+            @PathVariable Long bloodPostId
+    ) {
+        BloodPostDto.ExpireResponse response = bloodPostService.expireBloodPost(bloodPostId);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.BLOODPOST_EXPIRE_SUCCESS, response));
+    }
+
+    @ApiOperation("헌혈 요청글 끌어올리기")
+    @PatchMapping("/pull/{bloodPostId}")
+    public ResponseEntity<ResultResponse> pullBloodPost(
+            @PathVariable Long bloodPostId
+    ) {
+        BloodPostDto.PullResponse response = bloodPostService.pullBloodPost(bloodPostId);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.BLOODPOST_EXPIRE_SUCCESS, response));
+    }
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/bloodpost/dto/BloodPostDto.java
+++ b/module-domain/src/main/java/com/zoopi/domain/bloodpost/dto/BloodPostDto.java
@@ -1,0 +1,148 @@
+package com.zoopi.domain.bloodpost.dto;
+
+import com.zoopi.domain.bloodpost.entity.BloodPost;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public class BloodPostDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RegisterRequest {
+        @NotNull
+        private Long petId;
+
+        @NotBlank
+        @Size(max = 100)
+        private String title;
+
+        @NotBlank
+        @Size(max = 300)
+        private String content;
+
+        @NotNull
+        @Min(1)
+        private int packCount;
+
+        @NotNull
+        private Long hospitalId;
+
+        public BloodPost toEntity() {
+            return BloodPost.builder()
+                    .petId(this.petId)
+                    .title(this.title)
+                    .content(this.content)
+                    .packCount(this.packCount)
+                    .hospitalId(this.hospitalId)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class UpdateRequest {
+        @NotBlank
+        @Size(max = 100)
+        private String title;
+
+        @NotBlank
+        @Size(max = 300)
+        private String content;
+
+        @NotNull
+        @Min(1)
+        private int packCount;
+
+        @NotNull
+        private Long hospitalId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class InfoResponse {
+        private final Long id;
+        private final Long petId;
+        private final String title;
+        private final String content;
+        private final int packCount;
+        private final Long hospitalId;
+        private final BloodPost.Status status;
+        private final LocalDateTime pullDate;
+        private final int pullCount;
+
+        public InfoResponse(BloodPost bloodPost) {
+            this.id = bloodPost.getId();
+            this.petId = bloodPost.getPetId();
+            this.title = bloodPost.getTitle();
+            this.content = bloodPost.getContent();
+            this.packCount = bloodPost.getPackCount();
+            this.hospitalId = bloodPost.getHospitalId();
+            this.status = bloodPost.getStatus();
+            this.pullDate = bloodPost.getPullDate();
+            this.pullCount = bloodPost.getPullCount();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class RegisterResponse {
+        private final Long id;
+
+        public RegisterResponse(BloodPost bloodPost) {
+            this.id = bloodPost.getId();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class UpdateResponse {
+        private final Long id;
+        private final String title;
+        private final String content;
+        private final int packCount;
+        private final Long hospitalId;
+
+        public UpdateResponse(BloodPost bloodPost) {
+            this.id = bloodPost.getId();
+            this.title = bloodPost.getTitle();
+            this.content = bloodPost.getContent();
+            this.packCount = bloodPost.getPackCount();
+            this.hospitalId = bloodPost.getHospitalId();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ExpireResponse {
+        private final Long id;
+
+        public ExpireResponse(BloodPost bloodPost) {
+            this.id = bloodPost.getId();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class PullResponse {
+        private final Long id;
+        private final LocalDateTime pullDate;
+        private final int pullCount;
+
+        public PullResponse(BloodPost bloodPost) {
+            this.id = bloodPost.getId();
+            this.pullDate = bloodPost.getPullDate();
+            this.pullCount = bloodPost.getPullCount();
+        }
+    }
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/bloodpost/entity/BloodPost.java
+++ b/module-domain/src/main/java/com/zoopi/domain/bloodpost/entity/BloodPost.java
@@ -1,0 +1,111 @@
+package com.zoopi.domain.bloodpost.entity;
+
+import com.zoopi.domain.BaseEntity;
+import com.zoopi.domain.bloodpost.dto.BloodPostDto;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "blood_posts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BloodPost extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "blood_post_id")
+    private Long id;
+
+    // TODO: 반려동물 엔티티 구현 시 수정
+    @Column(name = "pet_id", nullable = false)
+    private Long petId;
+
+    @Column(name = "title", nullable = false)
+    @Size(max = 100)
+    private String title;
+
+    @Column(name = "content", nullable = false)
+    @Size(max = 300)
+    private String content;
+
+    @Column(name = "pack_count", nullable = false)
+    private int packCount;
+
+    // TODO: 동물병원 데이터 이슈 해결 시 수정
+    @Column(name = "hospital_id", nullable = false)
+    private Long hospitalId;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column(name = "pull_date")
+    private LocalDateTime pullDate;
+
+    @Column(name = "pull_count", nullable = false)
+    private int pullCount;
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Status {
+        TODO("헌혈요청"),
+        PROGRESS("매칭완료"),
+        DONE("헌혈완료"),
+        EXPIRE("만료");
+
+        private final String description;
+    }
+
+    @Builder
+    public BloodPost(
+            Long petId,
+            String title,
+            String content,
+            int packCount,
+            Long hospitalId
+    ) {
+        this.petId = petId;
+        this.title = title;
+        this.content = content;
+        this.packCount = packCount;
+        this.hospitalId = hospitalId;
+        this.status = Status.TODO;
+        this.pullDate = LocalDateTime.now();
+        this.pullCount = 0;
+    }
+
+    public void todo() {
+        this.status = Status.TODO;
+    }
+
+    public void progress() {
+        this.status = Status.PROGRESS;
+    }
+
+    public void done() {
+        this.status = Status.DONE;
+    }
+
+    public void expire() {
+        this.status = Status.EXPIRE;
+    }
+
+    public void pull() {
+        this.pullDate = LocalDateTime.now();
+        this.pullCount++;
+    }
+
+    public void update(BloodPostDto.UpdateRequest request) {
+        this.title = request.getTitle();
+        this.content = request.getContent();
+        this.packCount = request.getPackCount();
+        this.hospitalId = request.getHospitalId();
+    }
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/bloodpost/repository/BloodPostRepository.java
+++ b/module-domain/src/main/java/com/zoopi/domain/bloodpost/repository/BloodPostRepository.java
@@ -1,0 +1,8 @@
+package com.zoopi.domain.bloodpost.repository;
+
+import com.zoopi.domain.bloodpost.entity.BloodPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BloodPostRepository extends JpaRepository<BloodPost, Long> {
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/bloodpost/repository/BloodPostRepositoryCustom.java
+++ b/module-domain/src/main/java/com/zoopi/domain/bloodpost/repository/BloodPostRepositoryCustom.java
@@ -1,0 +1,39 @@
+package com.zoopi.domain.bloodpost.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zoopi.domain.bloodpost.entity.BloodPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.zoopi.domain.bloodpost.entity.QBloodPost.bloodPost;
+import static org.springframework.util.StringUtils.hasText;
+
+@Repository
+@RequiredArgsConstructor
+public class BloodPostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<BloodPost> searchOrderByPullDateDesc(BloodPost.Status status, String title) {
+        return queryFactory.selectFrom(bloodPost)
+                .where(
+                        eqStatus(status),
+                        containsTitle(title)
+                )
+                .orderBy(bloodPost.pullDate.desc())
+                .fetch();
+    }
+
+    private BooleanExpression eqStatus(BloodPost.Status status) {
+        return !Objects.isNull(status) ? bloodPost.status.eq(status) : null;
+    }
+
+    private BooleanExpression containsTitle(String title) {
+        return hasText(title) ? bloodPost.title.contains(title) : null;
+    }
+
+}

--- a/module-domain/src/main/java/com/zoopi/domain/bloodpost/service/BloodPostService.java
+++ b/module-domain/src/main/java/com/zoopi/domain/bloodpost/service/BloodPostService.java
@@ -1,0 +1,77 @@
+package com.zoopi.domain.bloodpost.service;
+
+import com.zoopi.domain.bloodpost.dto.BloodPostDto;
+import com.zoopi.domain.bloodpost.entity.BloodPost;
+import com.zoopi.domain.bloodpost.repository.BloodPostRepository;
+import com.zoopi.domain.bloodpost.repository.BloodPostRepositoryCustom;
+import com.zoopi.exception.EntityNotFoundException;
+import com.zoopi.exception.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BloodPostService {
+
+    private final BloodPostRepository bloodPostRepository;
+    private final BloodPostRepositoryCustom bloodPostRepositoryCustom;
+
+    @Transactional(readOnly = true)
+    public List<BloodPostDto.InfoResponse> selectAllBloodPost(BloodPost.Status status, String title) {
+        return bloodPostRepositoryCustom.searchOrderByPullDateDesc(status, title).stream()
+                .map(bloodPost -> new BloodPostDto.InfoResponse(bloodPost))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public BloodPostDto.InfoResponse selectBloodPost(Long bloodPostId) {
+        return new BloodPostDto.InfoResponse(getBloodPost(bloodPostId));
+    }
+
+    @Transactional
+    public BloodPostDto.RegisterResponse registerBloodPost(BloodPost bloodPost) {
+        return new BloodPostDto.RegisterResponse(bloodPostRepository.save(bloodPost));
+    }
+
+    @Transactional
+    public BloodPostDto.UpdateResponse updateBloodPost(Long bloodPostId, BloodPostDto.UpdateRequest request) {
+        BloodPost bloodPost = getBloodPost(bloodPostId);
+
+        bloodPost.update(request);
+
+        return new BloodPostDto.UpdateResponse(bloodPost);
+    }
+
+    @Transactional
+    public void deleteBloodPost(Long bloodPostId) {
+        bloodPostRepository.deleteById(bloodPostId);
+    }
+
+    @Transactional
+    public BloodPostDto.ExpireResponse expireBloodPost(Long bloodPostId) {
+        BloodPost bloodPost = getBloodPost(bloodPostId);
+
+        bloodPost.expire();
+
+        return new BloodPostDto.ExpireResponse(bloodPost);
+    }
+
+    @Transactional
+    public BloodPostDto.PullResponse pullBloodPost(Long bloodPostId) {
+        BloodPost bloodPost = getBloodPost(bloodPostId);
+
+        bloodPost.pull();
+
+        return new BloodPostDto.PullResponse(bloodPost);
+    }
+
+    private BloodPost getBloodPost(Long bloodPostId) {
+        return bloodPostRepository.findById(bloodPostId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BLOODPOST_NOT_FOUND));
+    }
+
+}

--- a/module-domain/src/main/java/com/zoopi/exception/response/ErrorCode.java
+++ b/module-domain/src/main/java/com/zoopi/exception/response/ErrorCode.java
@@ -36,6 +36,9 @@ public enum ErrorCode {
 	MEMBER_NOT_FOUND(400, "E-M001", "존재하지 않는 회원입니다"),
 	PASSWORD_MISMATCHED(400, "E-M002", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 
+	// BloodPost
+	BLOODPOST_NOT_FOUND(400, "E-BP001", "존재하지 않는 헌혈 요청글입니다."),
+
 	;
 
 	private final int status;


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌 Linked Issues
- resolve: #22 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## 🔎 Change Details
### 헌혈 요청글 엔티티 및 도메인 로직 작성
끌어올리기 기능을 위해 pull_date, pull_count 컬럼을 추가하고 erd cloud에도 반영

연관관계가 있는 반려동물, 동물병원 엔티티가 현재 존재하지 않아 id값으로 임시 작성

### 헌혈 요청글 API 구현
- 헌혈 요청글 리스트 조회(Status, Title로 필터링, 끌어올린 날짜 desc)
- 헌혈 요청글 상세 조회
- 헌혈 요청글 등록
- 헌혈 요청글 수정
- 헌혈 요청글 삭제
- 헌혈 요청글 끌어올리기
- 헌혈 요청글 만료

동적 where절이 필요한 리스트 조회의 경우 spring data jpa의 query method를 사용하게 되면 메서드 이름이 너무 길어져 가독성이 떨어지고, 조건이 많아지는 만큼 많은 메서드를 만들어야 하는 단점이 있기 때문에, querydsl과 BooleanExpression을 사용하여 구현

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬 Comment
- 현재 head 버전에 문제가 있어 권한에 대한 부분은 제외하고 구현하였음, 추후 해결 시 권한 관련 로직 및 테스트 코드 작성 예정
- 오버헤드를 최대한 줄이기 위해 nested class로 각 응답에 대한 세부 dto 클래스를 작성하였으며, 클라이언트와 QA 진행하며 필요한 데이터만을 제공할 예정
- 프로토타입 개발이 목표이기 때문에 어느 정도의 결합도를 허용하여 구현, 추후 DIP, facade 패턴 등을 적용하여 레이어간 결합도를 최소화하도록 리팩토링할 예정
- ex) Controller -> Facade -> Service <- ServiceImpl
- ex) ServiceImpl -> Reader <- ReaderImpl -> Repository

<!--
✅ 참고한 문서가 있다면 공유해 주세요.
-->
## 📑 References
- 

## ✅ Check Lists
- [ ] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
- [x] merge할 base branch가 올바른지 확인하셨나요?
