### PR TITLE
Swagger 명세서 업데이트

### DIFF
--- a/module-model/src/main/java/com/zoopi/Void.java
+++ b/module-model/src/main/java/com/zoopi/Void.java
@@ -1,0 +1,5 @@
+package com.zoopi;
+
+public final class Void {
+
+}

--- a/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
+++ b/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
@@ -19,8 +19,54 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import com.zoopi.ErrorResponse;
 import com.zoopi.ResultResponse;
+import com.zoopi.Void;
+import com.zoopi.client.member.model.SigninResponse;
+import com.zoopi.client.phoneauthentication.model.PhoneAuthenticationResponse;
 
+/**
+ * <b>Swagger Annotation 사용 가이드</b><br>
+ * 1. <b>@Api(tags = API 분류)</b>는 interface 단위에 추가한다.<br>
+ * <br>
+ *
+ * 2. <b>@ApiOperation(value = API 명)</b>은 method 단위에 추가한다.<br>
+ * <br>
+ *
+ * 3. <b>@ApiResponse</b> 작성 가이드<br>
+ * &nbsp; - <b>200</b><br>
+ * &nbsp;&nbsp; - code는 201부터 1씩 증가시키며 작성한다. <br>
+ * &nbsp;&nbsp; - message는 ResultCode의 status, code, message를 작성한다. <br>
+ * &nbsp;&nbsp; - response는 응답 모델 클래스를 작성한다. <br>
+ * &nbsp;&nbsp; ※ 단, response 클래스가 동일한 경우, 하나의 <b>@ApiResponse</b>의 message에 추가로 작성한다. <br>
+ * &nbsp;&nbsp; ※ 단, data에 어떤 값도 넣지 않을 경우, response에 zoopi.Void.class를 작성한다. <br>
+ * &nbsp; - <b>400</b>: 여기에 작성하지 않고, <b>@ApiOperation(notes = "")</b>에 예외가 발생하지 않게 API를 호출하는 시나리오를 작성한다.<br>
+ * &nbsp; - <b>500</b>: 공통적으로 아래 코드를 사용한다.<br>
+ * &nbsp;&nbsp; @ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")<br>
+ * <br>
+ *
+ * 4. <b>@ApiImplicitParam</b>은 메소드 단위에 추가한다.<br>
+ * &nbsp; - <b>name</b>: 파라미터의 변수명을 작성한다.<br>
+ * &nbsp; - <b>value</b>: 파라미터 설명을 작성한다. Validation이 적용된 경우 괄호로 추가 정보를 작성한다.<br>
+ * &nbsp; - <b>required</b>: 파라미터가 필수인 경우만 true로 추가한다. (default: false)<br>
+ * &nbsp; - <b>example</b>: 예시 입력 데이터를 작성한다.<br>
+ * <br>
+ *
+ * 5. <b>@ApiModelProperty</b>는 멤버 변수 단위에 추가한다.<br>
+ * &nbsp; - <b>name</b>: 사용하지 않는다. (자동 적용)<br>
+ * &nbsp; - <b>value</b>: 파라미터 설명을 작성한다. Validation이 적용된 경우 괄호로 추가 정보를 작성한다.<br>
+ * &nbsp; - <b>required</b>: 파라미터가 필수인 경우만 true로 추가한다. (default: false)<br>
+ * &nbsp; - <b>example</b>: 예시 입력 데이터를 작성한다.<br>
+ * <br>
+ *
+ * <b>※ 주의 사항</b><br>
+ * - Dto -> Json 변환 과정에서 변수명이 is___ 인 경우, is가 제거되어 전달된다.<br>
+ * - 따라서, <b>@ApiModelProperty</b> 작성 시 주의해야 한다. (name에 is를 뺴고 추가해도 제대로 적용이 안됨)<br>
+ * - <b>@JsonProperty</b>와 함께 사용하면 된다. (둘 다 is를 빼기)<br>
+ *
+ * <br>
+ * @author seonpilKim
+ */
 @Api(tags = "회원 인증 API")
 @Validated
 @RequestMapping("/auth")
@@ -28,39 +74,99 @@ public interface MemberAuthApi {
 
 	@ApiOperation(value = "아이디 유효성 검사")
 	@ApiResponses({
-		@ApiResponse(code = 200, message = "[R-M001] 사용 가능한 아이디입니다.", response = ValidationResponse.class)
+		@ApiResponse(code = 201, response = ValidationResponse.class, message = ""
+			+ "status: 200 | code: R-M001 | message: 사용 가능한 아이디입니다.\n"
+			+ "status: 200 | code: R-M002 | message: 존재하는 아이디입니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
 	})
-	@ApiImplicitParam(name = "username", value = "아이디", required = true, example = "zoopi")
+	@ApiImplicitParam(name = "username", value = "아이디 (최대 30자)", required = true, example = "zoopi")
 	@PostMapping("/username/validate")
 	ResponseEntity<ResultResponse> validateUsername(@RequestParam @Size(max = 30) String username);
 
 	@ApiOperation(value = "휴대폰 번호 유효성 검사")
-	@ApiImplicitParam(name = "phone", value = "휴대폰 번호", required = true, example = "01012345678")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = ValidationResponse.class, message = ""
+			+ "status: 200 | code: R-M003 | message: 사용 가능한 휴대폰 번호입니다\n"
+			+ "status: 200 | code: R-M004 | message: 존재하는 휴대폰 번호입니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
+	@ApiImplicitParam(name = "phone", value = "휴대폰 번호 (정규표현식: ^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012345678")
 	@PostMapping("/phone/validate")
 	ResponseEntity<ResultResponse> validatePhone(
 		@RequestParam @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$") String phone);
 
 	@ApiOperation(value = "휴대폰 본인 인증 문자 전송")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = Void.class, message = "status: 200 | code: R-B001 | message: 인증번호 전송이 제한된 휴대폰 번호입니다. 24시간 후 재시도해 주세요."),
+		@ApiResponse(code = 202, response = PhoneAuthenticationResponse.class, message = ""
+			+ "status: 200 | code: R-A005 | message: 인증 코드 전송에 성공하였습니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
 	@PostMapping("/phone/send")
 	ResponseEntity<ResultResponse> sendAuthenticationCode(@Valid @RequestBody SendAuthCodeRequest request);
 
 	@ApiOperation(value = "인증 코드 확인")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = ValidationResponse.class, message = ""
+			+ "status: 200 | code: R-A001 | message: 만료된 인증 코드입니다.\n"
+			+ "status: 200 | code: R-A002 | message: 인증 코드가 일치하지 않습니다.\n"
+			+ "status: 200 | code: R-A003 | message: 인증 코드가 일치합니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
 	@PostMapping("/code/check")
 	ResponseEntity<ResultResponse> checkAuthenticationCode(@Valid @RequestBody AuthCodeCheckRequest request);
 
-	@ApiOperation(value = "일반 회원 가입")
+	@ApiOperation(value = "일반 회원 가입", notes = ""
+		+ "API를 호출하기 전, 아래 사항을 먼저 체크해 주세요.<br>"
+		+ "1. 비밀번호와 비밀번호 재확인이 일치하는지?<br>"
+		+ "2. 사용 가능한 username인지?<br>"
+		+ "3. 사용 가능한 phone인지?<br>")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = ValidationResponse.class, message = ""
+			+ "status: 200 | code: R-M002 | message: 존재하는 아이디입니다.\n"
+			+ "status: 200 | code: R-M004 | message: 존재하는 휴대폰 번호입니다.\n"
+			+ "status: 200 | code: R-A001 | message: 만료된 인증 코드입니다.\n"
+			+ "status: 200 | code: R-A002 | message: 인증 코드가 일치하지 않습니다."),
+		@ApiResponse(code = 202, response = Void.class, message = "status: 200 | code: R-M005 | message: 회원 가입에 성공하였습니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
 	@PostMapping("/signup")
 	ResponseEntity<ResultResponse> signup(@Valid @RequestBody SignupRequest request);
 
 	@ApiOperation(value = "일반 로그인")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = SigninResponse.class, message = ""
+			+ "status: 200 | code: R-M008 | message: 회원 아이디가 올바르지 않습니다.\n"
+			+ "status: 200 | code: R-M007 | message: 회원 비밀번호가 일치하지 않습니다.\n"
+			+ "status: 200 | code: R-M006 | message: 로그인에 성공하였습니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
 	@PostMapping("/signin")
 	ResponseEntity<ResultResponse> signin(@Valid @RequestBody SigninRequest request);
 
 	@ApiOperation(value = "아이디 찾기")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = ValidationResponse.class, message = ""
+			+ "status: 200 | code: R-A001 | message: 만료된 인증 코드입니다.\n"
+			+ "status: 200 | code: R-A002 | message: 인증 코드가 일치하지 않습니다."),
+		@ApiResponse(code = 202, response = UsernameResponse.class, message = "status: 200 | code: R-M009 | message: 회원 아이디 찾기에 성공하였습니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
 	@PostMapping("/find/username")
 	ResponseEntity<ResultResponse> findUsername(@Valid @RequestBody FindUsernameRequest request);
 
-	@ApiOperation(value = "비밀번호 찾기")
+	@ApiOperation(value = "비밀번호 찾기", notes = ""
+		+ "API를 호출하기 전, 아래 사항을 먼저 체크해 주세요.<br>"
+		+ "1. 비밀번호와 비밀번호 재확인이 일치하는지?<br>"
+		+ "2. 존재하는 username인지?<br>")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = ValidationResponse.class, message = ""
+			+ "status: 200 | code: R-M008 | message: 회원 아이디가 올바르지 않습니다.\n"
+			+ "status: 200 | code: R-A001 | message: 만료된 인증 코드입니다.\n"
+			+ "status: 200 | code: R-A002 | message: 인증 코드가 일치하지 않습니다."),
+		@ApiResponse(code = 202, response = Void.class, message = "status: 200 | code: R-M010 | message: 회원 비밀번호 변경에 성공하였습니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
 	@PostMapping("/find/password")
 	ResponseEntity<ResultResponse> findPassword(@Valid @RequestBody FindPasswordRequest request);
 

--- a/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
+++ b/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
@@ -79,9 +79,9 @@ public interface MemberAuthApi {
 			+ "status: 200 | code: R-M002 | message: 존재하는 아이디입니다."),
 		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
 	})
-	@ApiImplicitParam(name = "username", value = "아이디 (최대 30자)", required = true, example = "zoopi")
+	@ApiImplicitParam(name = "username", value = "아이디 (정규표현식: ^[A-Za-z0-9]{6,20}$)", required = true, example = "zoopi123")
 	@PostMapping("/username/validate")
-	ResponseEntity<ResultResponse> validateUsername(@RequestParam @Size(max = 30) String username);
+	ResponseEntity<ResultResponse> validateUsername(@RequestParam @Pattern(regexp = "^[A-Za-z0-9]{6,20}$") String username);
 
 	@ApiOperation(value = "휴대폰 번호 유효성 검사")
 	@ApiResponses({

--- a/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
+++ b/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
@@ -4,7 +4,6 @@ import static com.zoopi.client.member.model.MemberAuthDto.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;

--- a/module-model/src/main/java/com/zoopi/client/member/model/MemberAuthDto.java
+++ b/module-model/src/main/java/com/zoopi/client/member/model/MemberAuthDto.java
@@ -1,11 +1,14 @@
 package com.zoopi.client.member.model;
 
+import static com.zoopi.ResultCode.*;
 import static com.zoopi.util.Constants.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -14,10 +17,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import com.zoopi.domain.phoneauthentication.entity.PhoneAuthenticationResult;
-import com.zoopi.domain.phoneauthentication.entity.PhoneAuthenticationType;
 import com.zoopi.ResultCode;
 import com.zoopi.ResultResponse;
+import com.zoopi.domain.phoneauthentication.entity.PhoneAuthenticationResult;
+import com.zoopi.domain.phoneauthentication.entity.PhoneAuthenticationType;
 
 public class MemberAuthDto {
 
@@ -32,18 +35,18 @@ public class MemberAuthDto {
 		private PhoneAuthenticationType type;
 
 		@NotBlank
-		@Size(max = 50)
-		@ApiModelProperty(value = "인증 키", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
+		@Size(min = 36, max = 36)
+		@ApiModelProperty(value = "인증 키(36자)", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
 		private String authenticationKey;
 
 		@NotNull
 		@Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$")
-		@ApiModelProperty(value = "휴대폰 번호", required = true, example = "01012345678")
+		@ApiModelProperty(value = "휴대폰 번호(정규표현식: ^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012345678")
 		private String phone;
 
 		@NotBlank
 		@Size(min = 6, max = 6)
-		@ApiModelProperty(value = "인증 코드", required = true, example = "012345")
+		@ApiModelProperty(value = "인증 코드(6자)", required = true, example = "012345")
 		private String authenticationCode;
 
 	}
@@ -55,28 +58,28 @@ public class MemberAuthDto {
 	public static class FindPasswordRequest {
 
 		@NotBlank
-		@Size(max = 50)
-		@ApiModelProperty(value = "인증 키", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
+		@Size(max = 36)
+		@ApiModelProperty(value = "인증 키(36자)", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
 		private String authenticationKey;
 
 		@NotNull
 		@Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$")
-		@ApiModelProperty(value = "휴대폰 번호", required = true, example = "01012345678")
+		@ApiModelProperty(value = "휴대폰 번호(정규표현식: ^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012345678")
 		private String phone;
 
 		@NotBlank
 		@Size(max = 30)
-		@ApiModelProperty(value = "아이디", required = true, example = "zoopi123")
+		@ApiModelProperty(value = "아이디(최대 30자)", required = true, example = "zoopi123")
 		private String username;
 
 		@NotNull
 		@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
-		@ApiModelProperty(value = "비밀번호", required = true, example = "1234asdf!@#$")
+		@ApiModelProperty(value = "비밀번호(정규표현식:^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
 		private String password;
 
 		@NotNull
 		@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
-		@ApiModelProperty(value = "비밀번호 확인", required = true, example = "1234asdf!@#$")
+		@ApiModelProperty(value = "비밀번호 확인(정규표현식:^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
 		private String passwordCheck;
 
 	}
@@ -88,13 +91,13 @@ public class MemberAuthDto {
 	public static class FindUsernameRequest {
 
 		@NotBlank
-		@Size(max = 50)
-		@ApiModelProperty(value = "인증 키", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
+		@Size(max = 36)
+		@ApiModelProperty(value = "인증 키(36자)", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
 		private String authenticationKey;
 
 		@NotNull
 		@Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$")
-		@ApiModelProperty(value = "휴대폰 번호", required = true, example = "01012345678")
+		@ApiModelProperty(value = "휴대폰 번호(정규표현식:^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012345678")
 		private String phone;
 
 	}
@@ -124,12 +127,12 @@ public class MemberAuthDto {
 
 		@NotBlank
 		@Size(max = 30)
-		@ApiModelProperty(value = "아이디", required = true, example = "zoopi123")
+		@ApiModelProperty(value = "아이디(최대 30자)", required = true, example = "zoopi123")
 		private String username;
 
-		@Size(max = 30)
-		@NotBlank
-		@ApiModelProperty(value = "비밀번호", required = true, example = "1234asdf!@#$")
+		@NotNull
+		@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
+		@ApiModelProperty(value = "비밀번호(정규표현식: ^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
 		private String password;
 
 	}
@@ -142,27 +145,27 @@ public class MemberAuthDto {
 
 		@NotBlank
 		@Size(max = 30)
-		@ApiModelProperty(value = "아이디", required = true, example = "zoopi123")
+		@ApiModelProperty(value = "아이디(최대 30자)", required = true, example = "zoopi123")
 		private String username;
 
 		@NotNull
 		@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
-		@ApiModelProperty(value = "비밀번호", required = true, example = "1234asdf!@#$")
+		@ApiModelProperty(value = "비밀번호(정규표현식: ^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
 		private String password;
 
 		@NotNull
 		@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
-		@ApiModelProperty(value = "비밀번호 확인", required = true, example = "1234asdf!@#$")
+		@ApiModelProperty(value = "비밀번호 확인(정규표현식: ^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
 		private String passwordCheck;
 
 		@NotNull
 		@Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$")
-		@ApiModelProperty(value = "휴대폰 번호", required = true, example = "01012341234")
+		@ApiModelProperty(value = "휴대폰 번호(정규표현식:^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012341234")
 		private String phone;
 
 		@NotBlank
-		@Size(max = 50)
-		@ApiModelProperty(value = "인증 키", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
+		@Size(max = 36)
+		@ApiModelProperty(value = "인증 키(36자)", required = true, example = "2a6ec3d7-7147-4cdc-a6c5-fc5d937cfe76")
 		private String authenticationKey;
 
 	}
@@ -171,7 +174,11 @@ public class MemberAuthDto {
 	@AllArgsConstructor(access = AccessLevel.PROTECTED)
 	public static class ValidationResponse {
 
+		@ApiModelProperty(name = "value", value = "검증 대상(값)", example = "username | phone | ...")
 		private String value;
+
+		@JsonProperty(value = "validated")
+		@ApiModelProperty(name = "validated", value = "검증 결과", example = "true | false")
 		private boolean isValidated;
 
 		public static ValidationResponse of(String value, boolean isValidated) {
@@ -179,13 +186,13 @@ public class MemberAuthDto {
 		}
 
 		public static ResultResponse fromValidatingUsername(String username, boolean isAvailable) {
-			final ResultCode resultCode = isAvailable ? ResultCode.USERNAME_AVAILABLE : ResultCode.USERNAME_EXISTENT;
+			final ResultCode resultCode = isAvailable ? USERNAME_AVAILABLE : USERNAME_EXISTENT;
 			final ValidationResponse response = ValidationResponse.of(username, isAvailable);
 			return ResultResponse.of(resultCode, response);
 		}
 
 		public static ResultResponse fromValidatingPhone(String phone, boolean isAvailable) {
-			final ResultCode resultCode = isAvailable ? ResultCode.PHONE_AVAILABLE : ResultCode.PHONE_EXISTENT;
+			final ResultCode resultCode = isAvailable ? PHONE_AVAILABLE : PHONE_EXISTENT;
 			final ValidationResponse response = ValidationResponse.of(phone, isAvailable);
 			return ResultResponse.of(resultCode, response);
 		}
@@ -193,21 +200,20 @@ public class MemberAuthDto {
 		public static ResultResponse fromCheckingAuthenticationCode(PhoneAuthenticationResult result, String value) {
 			switch (result) {
 				case EXPIRED:
-					return ResultResponse.of(ResultCode.AUTHENTICATION_CODE_EXPIRED, ValidationResponse.of(value, false));
+					return ResultResponse.of(AUTHENTICATION_CODE_EXPIRED, ValidationResponse.of(value, false));
 				case MISMATCHED:
-					return ResultResponse.of(
-						ResultCode.AUTHENTICATION_CODE_MISMATCHED, ValidationResponse.of(value, false));
+					return ResultResponse.of(AUTHENTICATION_CODE_MISMATCHED, ValidationResponse.of(value, false));
 				default:
-					return ResultResponse.of(ResultCode.AUTHENTICATION_CODE_MATCHED, ValidationResponse.of(value, true));
+					return ResultResponse.of(AUTHENTICATION_CODE_MATCHED, ValidationResponse.of(value, true));
 			}
 		}
 
 		public static ResultResponse fromCheckingUsername(boolean isExistentUsername, String username) {
 			if (isExistentUsername) {
-				return ResultResponse.of(ResultCode.USERNAME_EXISTENT);
+				return ResultResponse.of(USERNAME_EXISTENT);
 			} else {
 				final ValidationResponse response = ValidationResponse.of(username, false);
-				return ResultResponse.of(ResultCode.USERNAME_NONEXISTENT, response);
+				return ResultResponse.of(USERNAME_NONEXISTENT, response);
 			}
 		}
 
@@ -224,7 +230,7 @@ public class MemberAuthDto {
 		}
 
 		public static ResultResponse fromFindingUsername(String username) {
-			return ResultResponse.of(ResultCode.FIND_USERNAME_SUCCESS, UsernameResponse.of(username));
+			return ResultResponse.of(FIND_USERNAME_SUCCESS, UsernameResponse.of(username));
 		}
 
 	}
@@ -234,11 +240,11 @@ public class MemberAuthDto {
 		public static ResultResponse fromSigningIn(SigninResponse response) {
 			switch (response.getResult()) {
 				case NONEXISTENT_USERNAME:
-					return ResultResponse.of(ResultCode.USERNAME_NONEXISTENT, EMPTY);
+					return ResultResponse.of(USERNAME_NONEXISTENT, EMPTY);
 				case MISMATCHED_PASSWORD:
-					return ResultResponse.of(ResultCode.PASSWORD_MISMATCHED, EMPTY);
+					return ResultResponse.of(PASSWORD_MISMATCHED, EMPTY);
 				default:
-					return ResultResponse.of(ResultCode.SIGN_IN_SUCCESS, response.getJwt());
+					return ResultResponse.of(SIGN_IN_SUCCESS, response.getJwt());
 			}
 		}
 

--- a/module-model/src/main/java/com/zoopi/client/member/model/MemberAuthDto.java
+++ b/module-model/src/main/java/com/zoopi/client/member/model/MemberAuthDto.java
@@ -67,19 +67,19 @@ public class MemberAuthDto {
 		@ApiModelProperty(value = "휴대폰 번호(정규표현식: ^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012345678")
 		private String phone;
 
-		@NotBlank
-		@Size(max = 30)
-		@ApiModelProperty(value = "아이디(최대 30자)", required = true, example = "zoopi123")
+		@NotNull
+		@Pattern(regexp = "^[A-Za-z0-9]{6,20}$")
+		@ApiModelProperty(value = "아이디(정규표현식: ^[A-Za-z0-9]{6,20}$)", required = true, example = "zoopi123")
 		private String username;
 
 		@NotNull
 		@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
-		@ApiModelProperty(value = "비밀번호(정규표현식:^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
+		@ApiModelProperty(value = "비밀번호(정규표현식: ^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
 		private String password;
 
 		@NotNull
 		@Pattern(regexp = "^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$")
-		@ApiModelProperty(value = "비밀번호 확인(정규표현식:^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
+		@ApiModelProperty(value = "비밀번호 확인(정규표현식: ^.*(?=^.{10,20}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*()+=]).*$)", required = true, example = "1234asdf!@#$")
 		private String passwordCheck;
 
 	}
@@ -97,7 +97,7 @@ public class MemberAuthDto {
 
 		@NotNull
 		@Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$")
-		@ApiModelProperty(value = "휴대폰 번호(정규표현식:^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012345678")
+		@ApiModelProperty(value = "휴대폰 번호(정규표현식: ^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012345678")
 		private String phone;
 
 	}
@@ -125,9 +125,9 @@ public class MemberAuthDto {
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	public static class SigninRequest {
 
-		@NotBlank
-		@Size(max = 30)
-		@ApiModelProperty(value = "아이디(최대 30자)", required = true, example = "zoopi123")
+		@NotNull
+		@Pattern(regexp = "^[A-Za-z0-9]{6,20}$")
+		@ApiModelProperty(value = "아이디(정규표현식: ^[A-Za-z0-9]{6,20}$)", required = true, example = "zoopi123")
 		private String username;
 
 		@NotNull
@@ -143,9 +143,9 @@ public class MemberAuthDto {
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	public static class SignupRequest {
 
-		@NotBlank
-		@Size(max = 30)
-		@ApiModelProperty(value = "아이디(최대 30자)", required = true, example = "zoopi123")
+		@NotNull
+		@Pattern(regexp = "^[A-Za-z0-9]{6,20}$")
+		@ApiModelProperty(value = "아이디(정규표현식: ^[A-Za-z0-9]{6,20}$)", required = true, example = "zoopi123")
 		private String username;
 
 		@NotNull
@@ -160,7 +160,7 @@ public class MemberAuthDto {
 
 		@NotNull
 		@Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$")
-		@ApiModelProperty(value = "휴대폰 번호(정규표현식:^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012341234")
+		@ApiModelProperty(value = "휴대폰 번호(정규표현식: ^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$)", required = true, example = "01012341234")
 		private String phone;
 
 		@NotBlank

--- a/module-model/src/main/java/com/zoopi/swagger/SwaggerConfig.java
+++ b/module-model/src/main/java/com/zoopi/swagger/SwaggerConfig.java
@@ -8,13 +8,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.bind.annotation.RestController;
 
 import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.schema.ModelRef;
 import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Parameter;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -25,25 +26,31 @@ public class SwaggerConfig {
 	@Bean
 	public Docket api() {
 		return new Docket(DocumentationType.SWAGGER_2)
-			.globalOperationParameters(globalOperation())
 			.useDefaultResponseMessages(false)
 			.apiInfo(apiInfo())
+			.securityContexts(List.of(securityContext()))
+			.securitySchemes(List.of(apiKey()))
 			.select()
 			.apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
 			.paths(PathSelectors.any())
 			.build();
 	}
 
-	private List<Parameter> globalOperation() {
-		final List<Parameter> global = new ArrayList<>();
-		global.add(new ParameterBuilder()
-			.name("Authorization")
-			.description("Access Token")
-			.parameterType("header")
-			.modelRef(new ModelRef("string"))
-			.scalarExample("Bearer AAA.BBB.CCC")
-			.build());
-		return global;
+	private ApiKey apiKey() {
+		return new ApiKey("Access Token (JWT)", "Authorization", "header");
+	}
+
+	private SecurityContext securityContext() {
+		return SecurityContext.builder()
+			.securityReferences(defaultAuth())
+			.build();
+	}
+
+	private List<SecurityReference> defaultAuth() {
+		final AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEveryThing");
+		final AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+		authorizationScopes[0] = authorizationScope;
+		return List.of(new SecurityReference("JWT", authorizationScopes));
 	}
 
 	private ApiInfo apiInfo() {
@@ -53,4 +60,5 @@ public class SwaggerConfig {
 			.description("API 명세서")
 			.build();
 	}
+
 }


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌 Linked Issues
- Resolve: #34 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## 🔎 Change Details
- 회원 인증(/auth) api의 swagger 명세서를 업데이트 하였습니다.
    - request/response model의 각 필드에 검증 로직에 대한 설명도 추가하였습니다.
    - 각 api마다 `@ApiResponse`를 추가하였습니다.

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬 Comment
- Swagger 명세서 작성 가이드를 MemberAuthApi에 주석으로 작성하였습니다.
    - 일단 제가 생각하는 가이드라인을 작성해봤는데, 피드백 부탁드립니다🙏

<!--
✅ 참고한 문서가 있다면 공유해 주세요.
-->
## 📑 References
- 

## ✅ Check Lists
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
- [x] merge할 base branch가 올바른지 확인하셨나요?
