### PR TITLE
간편 로그인(app) API 추가 및 OAuth2 로직 리팩토링

### DIFF
--- a/module-application/src/main/java/com/zoopi/client/member/controller/MemberAuthController.java
+++ b/module-application/src/main/java/com/zoopi/client/member/controller/MemberAuthController.java
@@ -92,7 +92,7 @@ public class MemberAuthController implements MemberAuthApi {
 
 		response = ValidationResponse.fromCheckingAuthenticationCode(result, request.getPhone());
 		if (response.getCode().equals(AUTHENTICATION_CODE_MATCHED.getCode())) {
-			memberService.createMember(request.getUsername(), request.getPhone(), EMPTY, request.getPassword(), EMPTY);
+			memberService.signup(request.getUsername(), request.getPhone(), EMPTY, request.getPassword(), EMPTY);
 			response = ResultResponse.of(SIGN_UP_SUCCESS);
 		}
 

--- a/module-application/src/main/java/com/zoopi/client/member/controller/MemberOAuth2Controller.java
+++ b/module-application/src/main/java/com/zoopi/client/member/controller/MemberOAuth2Controller.java
@@ -1,0 +1,43 @@
+package com.zoopi.client.member.controller;
+
+import static com.zoopi.ResultCode.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.zoopi.ResultResponse;
+import com.zoopi.client.member.api.MemberOAuth2Api;
+import com.zoopi.client.member.model.JwtDto;
+import com.zoopi.client.member.model.SigninAppRequest;
+import com.zoopi.client.member.service.MemberService;
+import com.zoopi.client.member.service.OAuth2Service;
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.infra.oauth2.OAuth2LoginService;
+import com.zoopi.security.oauth2.OAuth2Attributes;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberOAuth2Controller implements MemberOAuth2Api {
+
+	private final OAuth2LoginService oAuth2LoginService;
+	private final OAuth2Service oAuth2Service;
+	private final MemberService memberService;
+
+	@Override
+	public void authorize(String provider) {}
+
+	@Override
+	public void callback(String provider, String code, String status) {}
+
+	@Override
+	public ResponseEntity<ResultResponse> signinApp(SigninAppRequest request) {
+		final OAuth2Attributes oAuth2Attributes = oAuth2LoginService.getOAuth2Attributes(request.getProvider(),
+			request.getCode(), request.getStatus());
+		final Member member = oAuth2Service.getMember(oAuth2Attributes);
+		final JwtDto jwtDto = memberService.generateJwt(member);
+		return ResponseEntity.ok(ResultResponse.of(SIGN_IN_SUCCESS, jwtDto));
+	}
+
+}

--- a/module-application/src/main/java/com/zoopi/client/member/service/MemberService.java
+++ b/module-application/src/main/java/com/zoopi/client/member/service/MemberService.java
@@ -12,10 +12,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.zoopi.client.member.model.JwtDto;
 import com.zoopi.client.member.model.SigninResponse;
 import com.zoopi.domain.member.entity.Member;
 import com.zoopi.domain.member.repository.MemberRepository;
-import com.zoopi.client.member.model.JwtDto;
 import com.zoopi.exception.EntityNotFoundException;
 import com.zoopi.util.JwtUtils;
 
@@ -37,7 +37,7 @@ public class MemberService {
 	}
 
 	@Transactional
-	public Member createMember(String username, String phone, String name, String password, String email) {
+	public Member signup(String username, String phone, String name, String password, String email) {
 		final Member member = Member.builder()
 			.username(username)
 			.password(passwordEncoder.encode(password))
@@ -79,7 +79,7 @@ public class MemberService {
 		return true;
 	}
 
-	private JwtDto generateJwt(Member member) {
+	public JwtDto generateJwt(Member member) {
 		final String accessToken = jwtUtils.generateAccessToken(member);
 		final String refreshToken = jwtUtils.generateRefreshToken(member);
 		return new JwtDto(accessToken, refreshToken);

--- a/module-application/src/main/java/com/zoopi/client/member/service/OAuth2Service.java
+++ b/module-application/src/main/java/com/zoopi/client/member/service/OAuth2Service.java
@@ -1,0 +1,48 @@
+package com.zoopi.client.member.service;
+
+import static com.zoopi.util.Constants.*;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.zoopi.domain.member.entity.Member;
+import com.zoopi.domain.member.entity.oauth2.SnsAccount;
+import com.zoopi.domain.member.entity.oauth2.SnsAccountPrimaryKey;
+import com.zoopi.domain.member.entity.oauth2.SnsProvider;
+import com.zoopi.security.oauth2.OAuth2Attributes;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2Service {
+
+	private final static String OAUTH2_USERNAME_PREFIX = "user";
+
+	private final MemberService memberService;
+	private final SnsAccountService snsAccountService;
+
+	@Transactional
+	public Member getMember(OAuth2Attributes oAuth2Attributes) {
+		final SnsProvider provider = SnsProvider.valueOf(oAuth2Attributes.getProvider());
+		final String userId = oAuth2Attributes.getAttributeKey();
+		final SnsAccountPrimaryKey primaryKey = new SnsAccountPrimaryKey(provider, userId);
+		return snsAccountService.getWithMember(primaryKey)
+			.map(SnsAccount::getMember)
+			.orElseGet(() -> signup(primaryKey, oAuth2Attributes));
+	}
+
+	private Member signup(SnsAccountPrimaryKey primaryKey, OAuth2Attributes oAuth2Attributes) {
+		final String username = OAUTH2_USERNAME_PREFIX + DELIMITER + System.currentTimeMillis();
+		final String password = UUID.randomUUID().toString();
+		final String phone = oAuth2Attributes.getPhone();
+		final String email = oAuth2Attributes.getEmail();
+		final Member member = memberService.signup(username, phone, EMPTY, password, email);
+		snsAccountService.connect(member, primaryKey);
+
+		return member;
+	}
+
+}

--- a/module-application/src/main/java/com/zoopi/infra/oauth2/OAuth2LoginService.java
+++ b/module-application/src/main/java/com/zoopi/infra/oauth2/OAuth2LoginService.java
@@ -1,0 +1,29 @@
+package com.zoopi.infra.oauth2;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.zoopi.domain.member.entity.oauth2.SnsProvider;
+import com.zoopi.infra.oauth2.naver.NaverLoginClient;
+import com.zoopi.security.oauth2.OAuth2Attributes;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2LoginService {
+
+	private final NaverLoginClient naverLoginClient;
+
+	public OAuth2Attributes getOAuth2Attributes(SnsProvider provider, String code, String status) {
+		switch (provider) {
+			case NAVER:
+				final String accessToken = naverLoginClient.issueAccessToken(code, status).getAccessToken();
+				final OAuth2Attributes oAuth2Attributes = naverLoginClient.getOAuth2Attributes(accessToken);
+				naverLoginClient.deleteAccessToken(accessToken);
+				return oAuth2Attributes;
+			default:
+				throw new IllegalArgumentException();
+		}
+	}
+
+}

--- a/module-application/src/main/java/com/zoopi/infra/oauth2/naver/NaverLoginClient.java
+++ b/module-application/src/main/java/com/zoopi/infra/oauth2/naver/NaverLoginClient.java
@@ -1,0 +1,77 @@
+package com.zoopi.infra.oauth2.naver;
+
+import static com.zoopi.util.Constants.*;
+import static org.springframework.http.HttpMethod.*;
+import static org.springframework.http.MediaType.*;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.zoopi.infra.oauth2.naver.dto.TokenRequest;
+import com.zoopi.infra.oauth2.naver.dto.TokenResponse;
+import com.zoopi.infra.oauth2.naver.dto.UserInfoResponse;
+import com.zoopi.security.oauth2.OAuth2Attributes;
+import com.zoopi.util.JwtUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverLoginClient {
+
+	private final RestTemplate restTemplate;
+
+	@Value("${spring.security.oauth2.client.provider.naver.user-info-uri}")
+	private String USER_INFO_URI;
+	@Value("${spring.security.oauth2.client.provider.naver.token-uri}")
+	private String TOKEN_URI;
+	@Value("${spring.security.oauth2.client.registration.naver.client-id}")
+	private String CLIENT_ID;
+	@Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+	private String CLIENT_SECRET;
+
+	public OAuth2Attributes getOAuth2Attributes(String accessToken) {
+		return getUserInfoResponse(accessToken).toOAuth2Attributes();
+	}
+
+	public TokenResponse issueAccessToken(String code, String status) {
+		final TokenRequest tokenRequest = TokenRequest.newIssueRequest(CLIENT_ID, CLIENT_SECRET, code, status);
+		return getTokenResponse(tokenRequest);
+	}
+
+	public TokenResponse deleteAccessToken(String accessToken) {
+		final TokenRequest tokenRequest = TokenRequest.newDeleteRequest(CLIENT_ID, CLIENT_SECRET, accessToken);
+		final TokenResponse tokenResponse = getTokenResponse(tokenRequest);
+		if (tokenResponse.isSuccessToDeleteToken()) {
+			log.info("Access Token was deleted From Naver. Access Token={}", tokenResponse.getAccessToken());
+		} else {
+			log.warn("Access Token wasn't deleted From Naver. Access Token={}, Error Code={}, Error Message={}",
+				tokenResponse.getAccessToken(), tokenResponse.getError(), tokenResponse.getErrorDescription());
+		}
+		return tokenResponse;
+	}
+
+	private UserInfoResponse getUserInfoResponse(String accessToken) {
+		final HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.set(CONTENT_TYPE_HEADER, APPLICATION_FORM_URLENCODED_VALUE);
+		httpHeaders.set(AUTHORIZATION_HEADER, JwtUtils.TOKEN_TYPE + SPACE + accessToken);
+		final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(null, httpHeaders);
+		return restTemplate.exchange(USER_INFO_URI, GET, requestEntity, UserInfoResponse.class).getBody();
+	}
+
+	private TokenResponse getTokenResponse(TokenRequest tokenRequest) {
+		final RequestEntity<TokenRequest> requestEntity = RequestEntity
+			.post(TOKEN_URI)
+			.contentType(APPLICATION_JSON)
+			.body(tokenRequest);
+		return restTemplate.exchange(requestEntity, TokenResponse.class).getBody();
+	}
+
+}

--- a/module-application/src/main/java/com/zoopi/infra/oauth2/naver/dto/TokenRequest.java
+++ b/module-application/src/main/java/com/zoopi/infra/oauth2/naver/dto/TokenRequest.java
@@ -1,0 +1,75 @@
+package com.zoopi.infra.oauth2.naver.dto;
+
+import static com.zoopi.domain.member.entity.oauth2.SnsProvider.*;
+import static com.zoopi.infra.oauth2.naver.dto.TokenRequest.GrantTypes.*;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Reference: <a href="https://developers.naver.com/docs/login/api/api.md">NAVER Developers</a>
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TokenRequest {
+
+	private String grantType;
+	private String clientId;
+	private String clientSecret;
+	private String code;
+	private String state;
+	private String refreshToken;
+	private String accessToken;
+	private String serviceProvider;
+
+	public static TokenRequest newIssueRequest(String clientId, String clientSecret, String code, String state) {
+		return TokenRequest.builder()
+			.grantType(ISSUE.getType())
+			.clientId(clientId)
+			.clientSecret(clientSecret)
+			.code(code)
+			.state(state)
+			.build();
+	}
+
+	public static TokenRequest newRefreshRequest(String clientId, String clientSecret, String refreshToken) {
+		return TokenRequest.builder()
+			.grantType(REFRESH.getType())
+			.clientId(clientId)
+			.clientSecret(clientSecret)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+	public static TokenRequest newDeleteRequest(String clientId, String clientSecret, String accessToken) {
+		return TokenRequest.builder()
+			.grantType(DELETE.getType())
+			.clientId(clientId)
+			.clientSecret(clientSecret)
+			.accessToken(accessToken)
+			.serviceProvider(NAVER.getProvider().toUpperCase())
+			.build();
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public enum GrantTypes {
+
+		ISSUE("authorization_code"),
+		REFRESH("refresh_token"),
+		DELETE("delete");
+
+		private String type;
+
+	}
+
+}

--- a/module-application/src/main/java/com/zoopi/infra/oauth2/naver/dto/TokenResponse.java
+++ b/module-application/src/main/java/com/zoopi/infra/oauth2/naver/dto/TokenResponse.java
@@ -1,0 +1,41 @@
+package com.zoopi.infra.oauth2.naver.dto;
+
+import static com.zoopi.infra.oauth2.naver.dto.TokenResponse.ResultTypes.*;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Reference: <a href="https://developers.naver.com/docs/login/api/api.md">NAVER Developers</a>
+ */
+@Getter
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TokenResponse {
+
+	private String accessToken;
+	private String refreshToken;
+	private String tokenType;
+	private String result;
+	private Integer expiresIn;
+	private String error;
+	private String errorDescription;
+
+	public boolean isSuccessToDeleteToken() {
+		return this.result.equals(SUCCESS.getType());
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public enum ResultTypes {
+
+		SUCCESS("success");
+
+		private String type;
+
+	}
+
+}

--- a/module-application/src/main/java/com/zoopi/infra/oauth2/naver/dto/UserInfoResponse.java
+++ b/module-application/src/main/java/com/zoopi/infra/oauth2/naver/dto/UserInfoResponse.java
@@ -1,0 +1,42 @@
+package com.zoopi.infra.oauth2.naver.dto;
+
+import static com.zoopi.domain.member.entity.oauth2.SnsProvider.*;
+import static com.zoopi.util.Constants.*;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import com.zoopi.security.oauth2.OAuth2Attributes;
+
+/**
+ * Reference: <a href="https://developers.naver.com/docs/login/profile/profile.md">NAVER Developers</a>
+ */
+@Getter
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserInfoResponse {
+
+	private String id;
+	private String nickname;
+	private String name;
+	private String email;
+	private String gender;
+	private String age;
+	private String birthday;
+	private String profileImage;
+	private String birthyear;
+	private String mobile;
+
+	public OAuth2Attributes toOAuth2Attributes() {
+		return OAuth2Attributes.builder()
+			.attributeKey(this.id)
+			.email(this.email)
+			.phone(this.mobile.replaceAll(DASH, EMPTY))
+			.provider(NAVER.getProvider())
+			.build();
+	}
+	
+}

--- a/module-application/src/main/java/com/zoopi/security/oauth2/CustomOAuth2UserService.java
+++ b/module-application/src/main/java/com/zoopi/security/oauth2/CustomOAuth2UserService.java
@@ -1,89 +1,28 @@
 package com.zoopi.security.oauth2;
 
-import static com.zoopi.util.Constants.*;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
+import com.zoopi.client.member.service.OAuth2Service;
 import com.zoopi.domain.member.entity.Member;
-import com.zoopi.domain.member.entity.oauth2.SnsAccount;
-import com.zoopi.domain.member.entity.oauth2.SnsAccountPrimaryKey;
-import com.zoopi.domain.member.entity.oauth2.SnsProvider;
-import com.zoopi.client.member.service.MemberService;
-import com.zoopi.client.member.service.SnsAccountService;
 
 @Component
 @RequiredArgsConstructor
-public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-	public final static String PRIMARY_KEY = "primary_key";
-	private final static String USERNAME_PREFIX = "user_";
-	private final MemberService memberService;
-	private final SnsAccountService snsAccountService;
-	private final PasswordEncoder passwordEncoder;
+	private final OAuth2Service oAuth2Service;
 
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) {
-		final OAuth2User oAuth2User = loadOAuth2User(userRequest);
-		final OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(userRequest, oAuth2User);
-		final Member member = loadMember(userRequest, oAuth2Attributes);
-		return convertToOAuth2User(member, oAuth2Attributes);
-	}
-
-	private OAuth2User loadOAuth2User(OAuth2UserRequest userRequest) {
-		final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
-		return oAuth2UserService.loadUser(userRequest);
-	}
-
-	private Member loadMember(OAuth2UserRequest userRequest, OAuth2Attributes oAuth2Attributes) {
-		final SnsAccountPrimaryKey primaryKey = getSnsAccountPrimaryKey(userRequest);
-		return snsAccountService.getWithMember(primaryKey)
-			.map(SnsAccount::getMember)
-			.orElse(signup(primaryKey, oAuth2Attributes.getEmail(), oAuth2Attributes.getPhone()));
-	}
-
-	private SnsAccountPrimaryKey getSnsAccountPrimaryKey(OAuth2UserRequest userRequest) {
-		final String registrationId = userRequest.getClientRegistration().getRegistrationId();
-		final SnsProvider provider = SnsProvider.valueOf(registrationId);
-		final String userNameAttributeName = userRequest.getClientRegistration()
-			.getProviderDetails()
-			.getUserInfoEndpoint()
-			.getUserNameAttributeName();
-		return new SnsAccountPrimaryKey(provider, userNameAttributeName);
-	}
-
-	private Member signup(SnsAccountPrimaryKey primaryKey, String email, String phone) {
-		final String username = USERNAME_PREFIX + System.currentTimeMillis();
-		final String password = passwordEncoder.encode(UUID.randomUUID().toString());
-		final Member member = memberService.createMember(username, phone, EMPTY, password, email);
-		snsAccountService.connect(member, primaryKey);
-
-		return member;
-	}
-
-	private OAuth2User convertToOAuth2User(Member member, OAuth2Attributes oAuth2Attributes) {
-		final List<SimpleGrantedAuthority> authorities = Arrays.stream(member.getAuthorities().split(","))
-			.map(SimpleGrantedAuthority::new)
-			.collect(Collectors.toList());
-
-		final Map<String, Object> attributes = oAuth2Attributes.convertToMap();
-		attributes.put(PRIMARY_KEY, member.getId());
-
-		return new DefaultOAuth2User(authorities, attributes, oAuth2Attributes.getAttributeKey());
+		final OAuth2User oAuth2User = super.loadUser(userRequest);
+		final String provider = userRequest.getClientRegistration().getRegistrationId().toUpperCase();
+		final OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(provider, oAuth2User.getAttributes());
+		final Member member = oAuth2Service.getMember(oAuth2Attributes);
+		return oAuth2Attributes.toOAuth2User(member);
 	}
 
 }

--- a/module-application/src/main/java/com/zoopi/security/oauth2/OAuth2Attributes.java
+++ b/module-application/src/main/java/com/zoopi/security/oauth2/OAuth2Attributes.java
@@ -2,10 +2,14 @@ package com.zoopi.security.oauth2;
 
 import static com.zoopi.util.Constants.*;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import lombok.AccessLevel;
@@ -13,13 +17,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import com.zoopi.security.oauth2.exception.UnsupportedPlatformSignInException;
+import com.zoopi.domain.member.entity.Member;
 import com.zoopi.domain.member.entity.oauth2.SnsProvider;
+import com.zoopi.security.oauth2.exception.UnsupportedPlatformSignInException;
 
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class OAuth2Attributes {
+
+	public final static String PRIMARY_KEY = "pk";
+	public final static String NAME_ATTRIBUTE_KEY = "nameAttributeKey";
+	public final static String PROVIDER_KEY = "provider";
+	public final static String PHONE_KEY = "phone";
+	public final static String EMAIL_KEY = "email";
 
 	private Map<String, Object> attributes;
 	private String provider;
@@ -27,37 +38,43 @@ public class OAuth2Attributes {
 	private String phone;
 	private String email;
 
-	public static OAuth2Attributes of(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+	public static OAuth2Attributes of(String provider, Map<String, Object> attributes) {
 		try {
-			final String registrationId = userRequest.getClientRegistration().getRegistrationId();
-			return of(SnsProvider.valueOf(registrationId), userRequest, oAuth2User.getAttributes());
+			return of(SnsProvider.valueOf(provider), attributes);
 		} catch (Exception e) {
 			throw new UnsupportedPlatformSignInException();
 		}
 	}
 
-	private static OAuth2Attributes of(SnsProvider snsProvider, OAuth2UserRequest userRequest, Map<String, Object> attributes) {
+	private static OAuth2Attributes of(SnsProvider snsProvider, Map<String, Object> attributes) {
 		final Map<String, Object> response = (Map<String, Object>)attributes.get(snsProvider.getResponse());
-		final String userNameAttributeName = userRequest.getClientRegistration()
-			.getProviderDetails()
-			.getUserInfoEndpoint()
-			.getUserNameAttributeName();
 		return OAuth2Attributes.builder()
 			.provider(snsProvider.getProvider())
-			.phone(response.containsKey(snsProvider.getPhone()) ? (String)response.get(snsProvider.getPhone()) : EMPTY)
+			.phone(response.containsKey(snsProvider.getPhone()) ?
+				response.get(snsProvider.getPhone()).toString().replaceAll(DASH, EMPTY) : EMPTY)
 			.email(response.containsKey(snsProvider.getEmail()) ? (String)response.get(snsProvider.getEmail()) : EMPTY)
 			.attributes(response)
-			.attributeKey(userNameAttributeName)
+			.attributeKey(response.get(snsProvider.getId()).toString())
 			.build();
 	}
 
-	public Map<String, Object> convertToMap() {
+	public OAuth2User toOAuth2User(Member member) {
+		final List<SimpleGrantedAuthority> authorities = Arrays.stream(member.getAuthorities().split(COMMA))
+			.map(SimpleGrantedAuthority::new)
+			.collect(Collectors.toList());
+
+		final Map<String, Object> attributes = toMap();
+		attributes.put(PRIMARY_KEY, member.getId());
+
+		return new DefaultOAuth2User(authorities, attributes, NAME_ATTRIBUTE_KEY);
+	}
+
+	private Map<String, Object> toMap() {
 		final Map<String, Object> map = new HashMap<>();
-		map.put("provider", this.provider);
-		map.put("id", this.attributeKey);
-		map.put("key", this.attributeKey);
-		map.put("phone", this.phone);
-		map.put("email", this.email);
+		map.put(NAME_ATTRIBUTE_KEY, this.attributeKey);
+		map.put(PROVIDER_KEY, this.provider);
+		map.put(PHONE_KEY, this.phone);
+		map.put(EMAIL_KEY, this.email);
 		return map;
 	}
 

--- a/module-application/src/main/java/com/zoopi/util/JwtUtils.java
+++ b/module-application/src/main/java/com/zoopi/util/JwtUtils.java
@@ -1,7 +1,7 @@
 package com.zoopi.util;
 
 import static com.zoopi.ErrorCode.*;
-import static com.zoopi.security.oauth2.CustomOAuth2UserService.*;
+import static com.zoopi.security.oauth2.OAuth2Attributes.*;
 import static com.zoopi.util.Constants.*;
 import static com.zoopi.util.JwtUtils.JwtType.*;
 
@@ -41,9 +41,10 @@ public class JwtUtils {
 	private static final String CLAIM_PRIMARY_KEY = "pk";
 	private static final String HEADER_TYPE = "typ";
 	private static final String TOKEN_NAME = "JWT";
-	private static final String TOKEN_TYPE = "Bearer"; // RFC 6750: JWT, OAuth 2.0 token are bearer tokens
 	private static final String TOKEN_ISSUER = "zoopi";
 	private static final int TOKEN_PREFIX_LENGTH = 7;
+
+	public static final String TOKEN_TYPE = "Bearer"; // RFC 6750: JWT, OAuth 2.0 token are bearer tokens
 
 	@Value("${jwt.access-validity}")
 	private long ACCESS_TOKEN_VALIDITY;

--- a/module-application/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
+++ b/module-application/src/test/java/com/zoopi/domain/member/service/MemberServiceTest.java
@@ -103,7 +103,7 @@ class MemberServiceTest {
 		given(memberRepository.save(any(Member.class))).willReturn(member);
 
 		// when
-		final Member savedMember = memberService.createMember(member.getUsername(), member.getPhone(), member.getName(),
+		final Member savedMember = memberService.signup(member.getUsername(), member.getPhone(), member.getName(),
 			member.getPassword(), member.getEmail());
 
 		// then

--- a/module-common/src/main/java/com/zoopi/util/Constants.java
+++ b/module-common/src/main/java/com/zoopi/util/Constants.java
@@ -7,8 +7,16 @@ import lombok.NoArgsConstructor;
 public final class Constants {
 
 	public static final String ALL_PATTERN = "/**";
+
+	public static final String BREAK_TAG = "<br>";
+
+	public static final String DASH = "-";
 	public static final String EMPTY = "";
 	public static final String SPACE = " ";
+	public static final String DELIMITER = "_";
+	public static final String COMMA = ",";
+
 	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String CONTENT_TYPE_HEADER = "Content-type";
 
 }

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/SnsAccount.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/SnsAccount.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "sns_acounts")
+@Table(name = "sns_accounts")
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/SnsProvider.java
+++ b/module-domain/src/main/java/com/zoopi/domain/member/entity/oauth2/SnsProvider.java
@@ -7,10 +7,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SnsProvider {
 
-    NAVER("naver", "response", "mobile", "email");
+    NAVER("NAVER", "response", "id", "mobile", "email");
 
     private final String provider;
     private final String response;
+    private final String id;
     private final String phone;
     private final String email;
 

--- a/module-model/src/main/java/com/zoopi/ErrorCode.java
+++ b/module-model/src/main/java/com/zoopi/ErrorCode.java
@@ -17,8 +17,8 @@ public enum ErrorCode {
 	REQUEST_HEADER_MISSING(400, "E-G007", "요청 헤더는 필수입니다."),
 
 	// Authorization
-	AUTHORIZATION_HEADER_MISSING(400, "E-A001", "인증 헤더는 필수입니다."),
-	BEARER_PREFIX_MISSING(400, "E-A002", "인증 헤더에 Bearer 접두사는 필수입니다."),
+	AUTHORIZATION_HEADER_MISSING(401, "E-A001", "인증 헤더는 필수입니다."),
+	BEARER_PREFIX_MISSING(401, "E-A002", "인증 헤더에 Bearer 접두사는 필수입니다."),
 	AUTHENTICATION_FAILURE(401, "E-A003", "인증에 실패하였습니다."),
 	INSUFFICIENT_AUTHORITY(403, "E-A004", "접근 권한이 부족합니다."),
 
@@ -26,11 +26,11 @@ public enum ErrorCode {
 	UNSUPPORTED_PLATFORM_SIGN_IN(400, "E-O001", "지원하지 않는 플랫폼 로그인입니다."),
 
 	// Jwt
-	JWT_INVALID(400, "E-J001", "유효하지 않은 토큰입니다."),
-	JWT_EXPIRED(400, "E-J002", "만료된 토큰입니다."),
-	JWT_MALFORMED(400, "E-J003", "구조가 올바르지 않은 토큰입니다."),
-	JWT_UNSUPPORTED(400, "E-J004", "지원하지 않는 형식의 토큰입니다."),
-	JWT_SIGNATURE_INVALID(400, "E-J005", "서명이 올바르지 않은 토큰입니다."),
+	JWT_INVALID(401, "E-J001", "유효하지 않은 토큰입니다."),
+	JWT_EXPIRED(401, "E-J002", "만료된 토큰입니다."),
+	JWT_MALFORMED(401, "E-J003", "구조가 올바르지 않은 토큰입니다."),
+	JWT_UNSUPPORTED(401, "E-J004", "지원하지 않는 형식의 토큰입니다."),
+	JWT_SIGNATURE_INVALID(401, "E-J005", "서명이 올바르지 않은 토큰입니다."),
 
 	// Member
 	MEMBER_NOT_FOUND(400, "E-M001", "존재하지 않는 회원입니다"),

--- a/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
+++ b/module-model/src/main/java/com/zoopi/client/member/api/MemberAuthApi.java
@@ -80,7 +80,8 @@ public interface MemberAuthApi {
 	})
 	@ApiImplicitParam(name = "username", value = "아이디 (정규표현식: ^[A-Za-z0-9]{6,20}$)", required = true, example = "zoopi123")
 	@PostMapping("/username/validate")
-	ResponseEntity<ResultResponse> validateUsername(@RequestParam @Pattern(regexp = "^[A-Za-z0-9]{6,20}$") String username);
+	ResponseEntity<ResultResponse> validateUsername(
+		@RequestParam @Pattern(regexp = "^[A-Za-z0-9]{6,20}$") String username);
 
 	@ApiOperation(value = "휴대폰 번호 유효성 검사")
 	@ApiResponses({
@@ -96,7 +97,8 @@ public interface MemberAuthApi {
 
 	@ApiOperation(value = "휴대폰 본인 인증 문자 전송")
 	@ApiResponses({
-		@ApiResponse(code = 201, response = Void.class, message = "status: 200 | code: R-B001 | message: 인증번호 전송이 제한된 휴대폰 번호입니다. 24시간 후 재시도해 주세요."),
+		@ApiResponse(code = 201, response = Void.class, message = ""
+			+ "status: 200 | code: R-B001 | message: 인증번호 전송이 제한된 휴대폰 번호입니다. 24시간 후 재시도해 주세요."),
 		@ApiResponse(code = 202, response = PhoneAuthenticationResponse.class, message = ""
 			+ "status: 200 | code: R-A005 | message: 인증 코드 전송에 성공하였습니다."),
 		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")

--- a/module-model/src/main/java/com/zoopi/client/member/api/MemberOAuth2Api.java
+++ b/module-model/src/main/java/com/zoopi/client/member/api/MemberOAuth2Api.java
@@ -1,0 +1,56 @@
+package com.zoopi.client.member.api;
+
+import static com.zoopi.util.Constants.*;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import com.zoopi.ErrorResponse;
+import com.zoopi.ResultResponse;
+import com.zoopi.client.member.model.SigninAppRequest;
+import com.zoopi.client.member.model.SigninResponse;
+
+@Api(tags = "회원 간편 인증 API")
+@RestController
+@RequestMapping("/oauth2")
+public interface MemberOAuth2Api {
+
+	@ApiOperation(value = "간편 로그인 페이지 이동", notes = ""
+		+ "간편 로그인 페이지로 redirect 후, 사용자가 로그인에 성공하면 \"http://localhost:3000/oauth2/callback/{provider}\"으로 redirect 됩니다." + BREAK_TAG
+		+ "해당 url의 query parameter에서 code와 state를 얻을 수 있습니다.")
+	@ApiImplicitParam(name = "provider", value = "OAuth2 provider", required = true, example = "naver")
+	@GetMapping("/authorization/{provider}")
+	void authorize(@PathVariable String provider);
+
+	@ApiOperation(value = "간편 로그인 인증 코드 전달", notes = ""
+		+ "먼저 간편 로그인 페이지 이동 API를 호출하여, redirect된 url의 query parameter에서 code와 state를 가져와서 API를 호출해야 합니다." + BREAK_TAG
+		+ "API를 호출하면, 서버에서 인증 코드를 가지고 provider의 Access Token을 획득하고, 이를 이용해 provider의 유저 정보를 얻어냅니다." + BREAK_TAG
+		+ "처음 로그인한 경우, 내부적으로 회원 가입 로직이 수행되며, 결과적으로 새로운 Access Token과 Refresh Token을 발급합니다.")
+	@ApiImplicitParam(name = "provider", value = "OAuth2 provider", required = true, example = "naver")
+	@GetMapping("/callback/{provider}")
+	void callback(@PathVariable String provider, @RequestParam String code, @RequestParam String status);
+
+	@ApiOperation(value = "간편 로그인(app)")
+	@ApiResponses({
+		@ApiResponse(code = 201, response = SigninResponse.class, message = ""
+			+ "status: 200 | code: R-M006 | message: 로그인에 성공하였습니다."),
+		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
+	})
+	@PostMapping(value = "/signin/app", headers = "AccessToken")
+	ResponseEntity<ResultResponse> signinApp(@Valid @RequestBody SigninAppRequest request);
+
+}

--- a/module-model/src/main/java/com/zoopi/client/member/api/MemberOAuth2Api.java
+++ b/module-model/src/main/java/com/zoopi/client/member/api/MemberOAuth2Api.java
@@ -50,7 +50,7 @@ public interface MemberOAuth2Api {
 			+ "status: 200 | code: R-M006 | message: 로그인에 성공하였습니다."),
 		@ApiResponse(code = 500, response = ErrorResponse.class, message = "Internal Server Error")
 	})
-	@PostMapping(value = "/signin/app", headers = "AccessToken")
+	@PostMapping(value = "/signin/app")
 	ResponseEntity<ResultResponse> signinApp(@Valid @RequestBody SigninAppRequest request);
 
 }

--- a/module-model/src/main/java/com/zoopi/client/member/model/SigninAppRequest.java
+++ b/module-model/src/main/java/com/zoopi/client/member/model/SigninAppRequest.java
@@ -1,0 +1,36 @@
+package com.zoopi.client.member.model;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.zoopi.domain.member.entity.oauth2.SnsProvider;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SigninAppRequest {
+
+	@NotNull
+	@ApiModelProperty(value = "OAuth2 플랫폼 제공자", required = true)
+	private SnsProvider provider;
+
+	@NotBlank
+	@Size(max = 50)
+	@ApiModelProperty(value = "인증 코드", required = true)
+	private String code;
+
+	@NotBlank
+	@Size(max = 50)
+	@ApiModelProperty(value = "csrf 방지 상태 토큰", required = true)
+	private String status;
+
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌 Linked Issues
- Reslove: #33 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## 🔎 Change Details
### 1. 간편 로그인(app) API 추가
#### 🔸 Flow
1. 클라이언트 단에서 소셜 로그인 API를 직접 호출하여 인증 코드를 얻은 뒤, 간편 로그인(app) API를 호출합니다.
2. 서버 단에서 인증 코드를 받아서 소셜 로그인 API를 호출하여 토큰을 발급받고, 유저 정보를 조회합니다.
3. 유저 pk를 통해 db를 조회하여 가입한 회원 여부를 판단한 후, 미가입자의 경우 회원가입 로직을 별도로 실행합니다.
4. 최종적으로 서버 단에서 새로 발급한 Access Token, Refresh Token을 클라이언트 단에 전달합니다.

### 2. 간편 로그인(web) 인증 코드 콜백 주소 변경
인증 코드 콜백을 프론트로 받는 방식으로 다시 변경하였습니다.
> 참고: [Redirect Flow](https://www.jessym.com/articles/stateless-oauth2-social-logins-with-spring-boot#improved-redirect-flow)

인증 코드 콜백을 백앤드로 받아도, 시큐리티 단에서 소셜 로그인 API를 호출해서 Access Token까지 받아오기는 하는데, 최종적으로 로그인 성공에 대한 응답을 프론트로 전달하는 과정이 잘 안되었습니다.

https://user-images.githubusercontent.com/68049320/188405018-ef64b8c0-a593-4fd3-aa0d-e07799aefebb.mp4

위 영상과 같이 최종 응답이 프론트가 아닌, 서버로 전달되더라구요..
`OAuth2SuccessHandler`의 `onAuthenticationSuccess` 메소드에 `response.sendRedirect` 메소드를 호출하면 프론트로 리다이렉트 될 수 있을 거라 생각했는데, 
```
java.lang.IllegalStateException: Cannot call sendRedirect() after the response has been committed
```
위 에러가 발생하면서 리다이렉트가 안되더라구요, 그래서 다시 콜백 주소를 프론트로 변경하였습니다 ㅠ_ㅠ

#### 🔸 Flow
1. 프론트 단에서 `{backend_host}/oauth2/authorization/{provider}` GET 호출
2. 서버 단에서 소셜 로그인 페이지 HTML을 응답
3. 사용자가 아이디, 비밀번호를 입력하고 로그인 버튼 클릭
4. 로그인 성공 시, `{front_host}/oauth2/callback/{provider}?code=&status=` 으로 Redirect
5. 프론트 단에서 위의 code와 status를 가져와서 `{backend_host}/oauth2/callback/{provider}?code=&status=` GET 호출
6. 서버 단에서 code, status를 가지고 소셜 로그인 API를 호출하여 토큰 획득 및 유저 정보를 받아옴
7. DB에 존재하지 않는 회원인 경우 별도로 회원가입 로직 실행
8. 서버 단에서 새로운 Access Token, Refresh Token을 발급해서 프론트 단에게 전달

### 3. 간편 로그인 API 명세서에 추가
> [Swagger](http://ec2-3-39-16-225.ap-northeast-2.compute.amazonaws.com:8080/swagger-ui.html#/%ED%9A%8C%EC%9B%90_%EA%B0%84%ED%8E%B8_%EC%9D%B8%EC%A6%9D_API)

- 간편 로그인 페이지 이동, 간편 로그인 인증 코드 전달 
    - 위 두 개는 프론트 분들이 사용할 API이고, endpoint와 호출 방식 소개를 위해 추가하였습니다.
    - 내부 로직은 Security 단에서 구현되어 있기 때문에, 컨트롤러 단에는 별도로 로직은 구현하지 않아 Swagger에서 테스트가 불가능합니다.
- 간편 로그인(app)
    - 안드로이드 분들이 사용할 API이고, Swagger에서 테스트가 가능합니다.

### 4. OAuth2 로직 리팩토링
#### `CustomOAuth2UserService`
- 의존성을 줄이고, 코드를 최대한 간단하게 리팩토링하였습니다.
- 기존의 `loadOAuth2User` 메소드는 호출 마다 객체를 생성하는 비효율적인 로직이라, 아예 상속 클래스를 `DefaultOAuth2UserService`으로 변경하고 `loadUser` 메소드 첫 줄에 `super.loadUser(userRequest)` 코드를 추가하였습니다.
    - 부모 메소드를 호출하여 얻은 OAuth2User 객체를 커스터마이징하여 반환합니다.
- 기존의 `loadMember` 메소드를 `OAuth2Service`에게 이관하였습니다.
    - Optional의 `orElse` 메소드는 해당 객체가 null이든 아니든 관계없이 무조건 호출되어, SnsAccount가 null이 아니어도 signup 메소드가 호출되는 문제가 있었습니다.
    - 해당 객체가 null일 때만 호출되는 `orElseGet` 메소드를 사용하는 코드로 수정하였습니다.
#### `OAuth2LoginService`
- 각 소셜 로그인 API vendor(naver, kakao, ...)로 부터 토큰을 얻고, 회원 정보를 받아와서 동일한 형태의 응답 객체(`OAuth2Attributes`)로 변환하여 반환하는 메소드를 추가하였습니다.
- 이후 vendor가 추가되면 switch문에 계속 추가하는 방식으로 확장할 수 있도록 구현하였습니다.
#### `NaverLoginClient`
- 네이버 아이디 로그인 API(네아로API)로 부터 토큰 발급/갱신/삭제와 회원 정보 조회를 할 수 있는 메소드를 구현하였습니다.
    - 토큰 갱신의 경우, 아직 사용되지 않아 메소드는 구현하지 않았으나, request dto는 정의된 상태입니다.
- 네아로 API는 요청 및 응답 데이터를 snake case로 사용하고 있어서, dto마다 `@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)`를 적용하였습니다.
    - 저희 코드에서 camel case를 계속 유지할 수 있고, objectmapper가 object <-> json 변환 시 snake case로 적용되어 변환됩니다.

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬 Comment
-

<!--
✅ 참고한 문서가 있다면 공유해 주세요.
-->
## 📑 References
- 

## ✅ Check Lists
- [ ] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
- [x] merge할 base branch가 올바른지 확인하셨나요?
